### PR TITLE
Use the up to date description for the update center

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@ THE SOFTWARE.
     <packaging>hpi</packaging>
 
     <name>Jenkins Design Library</name>
-    <description>Demonstration of UI controls available in Jenkins and guidance on how to use them.</description>
     <url>https://github.com/jenkinsci/design-library-plugin</url>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
     <packaging>hpi</packaging>
 
     <name>Jenkins Design Library</name>
-    <description>Demonstration of UI controls available in Jenkins and guidance on how to use them</description>
+    <description>Demonstration of UI controls available in Jenkins and guidance on how to use them.</description>
     <url>https://github.com/jenkinsci/design-library-plugin</url>
 
     <properties>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  Demonstration of UI controls available in Jenkins based on Stapler, Jelly, Groovy, etc.
+  Demonstration of UI controls available in Jenkins and guidance on how to use them.
 </div>


### PR DESCRIPTION
Currently, the old ui-samples text is displayed in the update center, instead of the up to date description.