### PR TITLE
Bump baseline to the first release shipping mandatory core components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/design-library-plugin</gitHubRepo>
-        <jenkins.version>2.339</jenkins.version>
+        <jenkins.version>2.341</jenkins.version>
         <java.level>8</java.level>
     </properties>
 


### PR DESCRIPTION
The build will fail for now, because the weekly did not run yet.