### PR TITLE
Temporarily remove simplified Chinese translations

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,8 +1,8 @@
 name: Crowdin Action
 
 on:
-  schedule:
-    - cron: '0 */12 * * *'
+#  schedule:
+#    - cron: '0 */12 * * *'
   workflow_dispatch:
 
 permissions:

--- a/src/main/resources/io/jenkins/plugins/designlibrary/AppBar/index_zh.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/AppBar/index_zh.properties
@@ -1,2 +1,0 @@
-title=页面标题
-description=应用栏提供了页面标题以及当前页面的重要动作。它必须包含在 <code>l:main-panel</code> 之前。


### PR DESCRIPTION
Addresses the convo in https://github.com/jenkinsci/design-library-plugin/pull/41 and pausing the cron based workflow for now, until I get around to investigate the underlaying issue.