### PR TITLE
Reenable cron based crowdin workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,8 +1,8 @@
 name: Crowdin Action
 
 on:
-#  schedule:
-#    - cron: '0 */12 * * *'
+  schedule:
+    - cron: '0 */12 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
@timja did you modify workflow permissions? The bottom checkbox of action PRs isn't ticked anymore, means GitHub actions can't create PRs at all: https://github.com/jenkinsci/design-library-plugin/settings/actions
And I can't tick it again 👀 