### PR TITLE
Gitpodify jenkins design library plugin

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
 tasks:
-  - init: npm install && npm run build && mvn install -DskipTests=false
+  - init: mvn install -P quick-build
     command: mvn hpi:run
   - command: gp await-port 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,3 +2,7 @@ tasks:
   - init: mvn install -P quick-build
     command: mvn hpi:run
   - command: gp await-port 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins
+
+github:
+  prebuilds:
+    pullRequestsFromForks: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+  - init: npm install && npm run build && mvn install -DskipTests=false
+    command: mvn hpi:run
+  - command: gp await-port 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ This plugin contains:
 
 ## Usage
 
-Run `mvn hpi:run`
+You can open this project as a [Gitpod workspace](https://www.gitpod.io/) which comes pre-configured with all the tools you will need.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin)
+
+If you prefer using IntelliJ IDEA, you can setup Gitpod integration with JetBrains Gateway using the instructions given [here](https://www.gitpod.io/docs/ides-and-editors/intellij), 
+which will open the workspace in IntelliJ IDEA using JetBrains Gateway.
+
+Alternatively clone this project and run `mvn hpi:run`
 
 Go to the **Design Library** menu item or straight to http://localhost:8080/jenkins/design-library/ and play with UI components.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can open this project as a [Gitpod workspace](https://www.gitpod.io/) which 
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin)
 
-If you prefer using IntelliJ IDEA, you can setup Gitpod integration with JetBrains Gateway using the instructions given [here](https://www.gitpod.io/docs/ides-and-editors/intellij), 
+If you prefer using IntelliJ IDEA, you can setup Gitpod integration with JetBrains Gateway using the instructions on [gitpod.io](https://www.gitpod.io/docs/ides-and-editors/intellij), 
 which will open the workspace in IntelliJ IDEA using JetBrains Gateway.
 
 Alternatively clone this project and run `mvn hpi:run`


### PR DESCRIPTION
This PR adds option to open this project in [Gitpod](https://github.com/gitpod-io) 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin)