### PR TITLE
Add previous/next buttons for samples pages

### DIFF
--- a/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
@@ -37,4 +37,20 @@ public abstract class UISample implements ExtensionPoint, Action, Describable<UI
     public static List<UISample> getAll() {
         return new ArrayList<>(Jenkins.get().getExtensionList(UISample.class));
     }
+
+    public UISample getPreviousPage() {
+        try {
+            return getAll().get(getAll().indexOf(this) - 1);
+        } catch (IndexOutOfBoundsException e) {
+            return null;
+        }
+    }
+
+    public UISample getNextPage() {
+        try {
+            return getAll().get(getAll().indexOf(this) + 1);
+        } catch (IndexOutOfBoundsException e) {
+            return null;
+        }
+    }
 }

--- a/src/main/resources/lib/samples/sample.jelly
+++ b/src/main/resources/lib/samples/sample.jelly
@@ -65,13 +65,13 @@ THE SOFTWARE.
         <j:if test="${it.previousPage != null}">
           <a href="${rootURL}/design-library/${it.previousPage.urlName}" class="jenkins-button jenkins-button--transparent jdl-previous-button">
             <l:icon src="symbol-arrow-left" />
-            <span>Previous</span>
+            <span>${%Previous}</span>
             <span>${it.previousPage.displayName}</span>
           </a>
         </j:if>
         <j:if test="${it.nextPage != null}">
           <a href="${rootURL}/design-library/${it.nextPage.urlName}" class="jenkins-button jenkins-button--transparent jdl-next-button">
-            <span>Next</span>
+            <span>${%Next}</span>
             <l:icon src="symbol-arrow-right" />
             <span>${it.nextPage.displayName}</span>
           </a>

--- a/src/main/resources/lib/samples/sample.jelly
+++ b/src/main/resources/lib/samples/sample.jelly
@@ -60,6 +60,23 @@ THE SOFTWARE.
 
     <l:main-panel>
       <d:invokeBody/>
+
+      <div class="jdl-previous-next-controls">
+        <j:if test="${it.previousPage != null}">
+          <a href="${rootURL}/design-library/${it.previousPage.urlName}" class="jenkins-button jenkins-button--transparent jdl-previous-button">
+            <l:icon src="symbol-arrow-left" />
+            <span>Previous</span>
+            <span>${it.previousPage.displayName}</span>
+          </a>
+        </j:if>
+        <j:if test="${it.nextPage != null}">
+          <a href="${rootURL}/design-library/${it.nextPage.urlName}" class="jenkins-button jenkins-button--transparent jdl-next-button">
+            <span>Next</span>
+            <l:icon src="symbol-arrow-right" />
+            <span>${it.nextPage.displayName}</span>
+          </a>
+        </j:if>
+      </div>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/scss/components/_index.scss
+++ b/src/main/resources/scss/components/_index.scss
@@ -1,2 +1,3 @@
 @use "component-sample";
 @use "source-block";
+@use "previous-next-controls";

--- a/src/main/resources/scss/components/_previous-next-controls.scss
+++ b/src/main/resources/scss/components/_previous-next-controls.scss
@@ -20,6 +20,8 @@
   .jdl-next-button {
     display: grid;
     grid-template-columns: auto auto;
+    font-size: 0.9rem;
+    gap: 0.5rem 0.75rem;
 
     span {
       margin: 0;
@@ -32,6 +34,8 @@
     }
 
     svg {
+      width: 1.1rem;
+      height: 1.1rem;
       transition: transform var(--elastic-transition);
     }
   }

--- a/src/main/resources/scss/components/_previous-next-controls.scss
+++ b/src/main/resources/scss/components/_previous-next-controls.scss
@@ -1,0 +1,63 @@
+.jdl-previous-next-controls {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  padding-top: var(--section-padding);
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: currentColor;
+    opacity: 0.05;
+    border-radius: 2px;
+  }
+
+  .jdl-previous-button,
+  .jdl-next-button {
+    display: grid;
+    grid-template-columns: auto auto;
+
+    span {
+      margin: 0;
+      padding: 0;
+
+      &:last-of-type {
+        opacity: 0.5;
+        margin-top: -0.3rem;
+      }
+    }
+
+    svg {
+      transition: transform var(--elastic-transition);
+    }
+  }
+
+  .jdl-previous-button {
+    justify-items: flex-start;
+
+    span:last-of-type {
+      grid-column: 2;
+    }
+
+    &:hover {
+      svg {
+        transform: translateX(-2px);
+      }
+    }
+  }
+
+  .jdl-next-button {
+    justify-items: flex-end;
+    margin-left: auto;
+
+    &:hover {
+      svg {
+        transform: translateX(2px);
+      }
+    }
+  }
+}

--- a/src/main/resources/scss/pages/_colors.scss
+++ b/src/main/resources/scss/pages/_colors.scss
@@ -21,6 +21,7 @@
   gap: 2rem 1rem;
   list-style-type: none;
   padding: 0;
+  margin-bottom: var(--section-padding);
 
   @media(max-width: 1300px){
     grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
<img width="923" alt="image" src="https://user-images.githubusercontent.com/43062514/168924582-1c86d243-95d7-47c4-b4cd-2da9199dbf74.png">

Small PR that adds a couple of handy links at the bottom of the page to go to the previous/next UI sample.