### PR TITLE
Revamp symbols page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/design-library-plugin</gitHubRepo>
-        <jenkins.version>2.348</jenkins.version>
+        <jenkins.version>2.350-rc32407.d15ca_b_52160b_</jenkins.version>
         <node.version>16.14.2</node.version>
         <npm.version>8.6.0</npm.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/design-library-plugin</gitHubRepo>
-        <jenkins.version>2.341</jenkins.version>
+        <jenkins.version>2.348</jenkins.version>
         <node.version>16.14.2</node.version>
         <npm.version>8.6.0</npm.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/design-library-plugin</gitHubRepo>
-        <jenkins.version>2.350-rc32407.d15ca_b_52160b_</jenkins.version>
+        <jenkins.version>2.350-rc32411.186041cf1c8b_</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/6614 -->
         <node.version>16.14.2</node.version>
         <npm.version>8.6.0</npm.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/design-library-plugin</gitHubRepo>
-        <jenkins.version>2.350-rc32411.186041cf1c8b_</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/6614 -->
+        <jenkins.version>2.350</jenkins.version>
         <node.version>16.14.2</node.version>
         <npm.version>8.6.0</npm.version>
     </properties>

--- a/src/main/java/io/jenkins/plugins/designlibrary/Symbols.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Symbols.java
@@ -4,27 +4,43 @@ import hudson.Extension;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.Stack;
 
 @Extension
 public class Symbols extends UISample {
-    @Override
-    public String getIconFileName() {
-        return "symbol-symbols";
-    }
+	@Override
+	public String getIconFileName() {
+		return "symbol-symbols";
+	}
 
-    public List<String> getSymbols() {
-        List<String> symbols = Arrays.asList("trash", "search", "rss", "ribbon", "reload", "plugins", "jenkins", "folder");
-        Collections.shuffle(symbols);
-        return symbols;
-    }
+	public Stack<String> getSymbols() {
+		Stack<String> symbols = new Stack<>();
+		symbols.addAll(Arrays.asList("trash",
+				"search",
+				"rss",
+				"ribbon",
+				"reload",
+				"plugins",
+				"jenkins",
+				"folder",
+				"play",
+				"fingerprint",
+				"details",
+				"people",
+				"terminal",
+				"edit",
+				"cloud",
+				"analytics",
+				"computer",
+				"download",
+				"hammer",
+				"key"));
+		Collections.shuffle(symbols);
+		return symbols;
+	}
 
-    public String getSymbol() {
-        return "symbol-" + getSymbols().get(0);
-    }
-
-    @Extension
-    public static final class DescriptorImpl extends UISampleDescriptor {
-    }
+	@Extension
+	public static final class DescriptorImpl extends UISampleDescriptor {
+	}
 }
 

--- a/src/main/java/io/jenkins/plugins/designlibrary/Symbols.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Symbols.java
@@ -2,14 +2,25 @@ package io.jenkins.plugins.designlibrary;
 
 import hudson.Extension;
 
-/**
- * @author Kohsuke Kawaguchi
- */
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 @Extension
 public class Symbols extends UISample {
     @Override
     public String getIconFileName() {
         return "symbol-symbols";
+    }
+
+    public List<String> getSymbols() {
+        List<String> symbols = Arrays.asList("trash", "search", "rss", "ribbon", "reload", "plugins", "jenkins", "folder");
+        Collections.shuffle(symbols);
+        return symbols;
+    }
+
+    public String getSymbol() {
+        return "symbol-" + getSymbols().get(0);
     }
 
     @Extension

--- a/src/main/resources/images/symbols/external.svg
+++ b/src/main/resources/images/symbols/external.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M384 224v184a40 40 0 01-40 40H104a40 40 0 01-40-40V168a40 40 0 0140-40h167.48M336 64h112v112M224 288L440 72" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/></svg>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -93,7 +93,7 @@
       <l:icon src="symbol-cube" class="icon-xlg" />
     </div>
     <pre class="jdl-symbols__symbol-code">
-      <code class="sample-remote language-xml" data-sample="symbol-alt.jelly" />
+      <code class="sample-remote language-xml" data-sample="symbol-size.jelly" />
     </pre>
 
     <a href="https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols"

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -1,12 +1,66 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="/lib/samples" xmlns:l="/lib/layout">
   <s:sample>
-    <p class="jenkins-description">${%title}</p>
+    <div class="jdl-symbols__masthead">
+      <div>
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+      </div>
+      <div>
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="symbol-symbols plugin-design-library" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+      </div>
+      <div>
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+        <l:icon src="${it.symbol}" />
+      </div>
+    </div>
 
-    <p>${%description}</p>
+    <p class="jdl-leading-paragraph">${%title}</p>
 
-    <h2>${%usage.title}</h2>
-    <p class="jenkins-description">${%usage.1}</p>
+    <hr/>
+
+    <table class="jdl-dos-donts">
+      <thead>
+        <tr>
+          <th class="jenkins-!-color-success-color">Do</th>
+          <th class="jenkins-!-color-error-color">Don't</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Symbols should be used to help a user recognise what a task does at a glance</td>
+          <td>Don't add symbols to headings</td>
+        </tr>
+        <tr>
+          <td>They should be recognisable and relevant, e.g. <l:icon src="symbol-lock-closed" /> for credentials</td>
+          <td>Dont add symbols to headings</td>
+        </tr>
+        <tr>
+          <td>Use a tooltip on the symbol if there isn't any accompanying text</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <hr/>
+
+    <h2 class="jdl-heading">${%usage.title}</h2>
+    <p class="jdl-paragraph">${%usage.1}</p>
     <p class="icon-md">
       <l:icon src="symbol-search" />
     </p>
@@ -14,7 +68,7 @@
       <code class="sample-remote language-xml" data-sample="symbol.jelly" />
     </pre>
 
-    <p class="jenkins-description">${%usage.2}</p>
+    <p class="jdl-paragraph">${%usage.2}</p>
     <p class="icon-md">
       <l:icon src="symbol-search" alt="Search" class="custom-class" />
     </p>
@@ -22,7 +76,7 @@
       <code class="sample-remote language-xml" data-sample="symbol-alt.jelly" />
     </pre>
 
-    <p class="jenkins-description">${%usage.3}</p>
+    <p class="jdl-paragraph">${%usage.3}</p>
 
     <ul style="list-style: none;">
       <li><span class="icon-sm"><l:icon src="symbol-search" alt="Search" class="custom-class" /></span> icon-sm</li>
@@ -35,12 +89,15 @@
       <code class="sample-remote language-xml" data-sample="symbol-size.jelly" />
     </pre>
 
+    <a href="https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols">
+      View the complete list of symbols available to use on GitHub
+    </a>
 
-    <h2>${%customSymbols}</h2>
-    <p class="jenkins-description">${%customSymbols.description.1}</p>
+    <h2 class="jdl-heading">${%customSymbols}</h2>
+    <p class="jdl-paragraph">${%customSymbols.description.1}</p>
     <pre><code>{plugin-root}/src/main/resources/images/symbols</code></pre>
 
-    <p class="jenkins-description">${%customSymbols.description.2}</p>
+    <p class="jdl-paragraph">${%customSymbols.description.2}</p>
     <pre>
       <code class="sample-remote language-xml" data-sample="symbol-plugin.jelly"/>
     </pre>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -38,8 +38,8 @@
     <table class="jdl-dos-donts">
       <thead>
         <tr>
-          <th class="jenkins-!-color-success-color">Do</th>
-          <th class="jenkins-!-color-error-color">Don't</th>
+          <th class="jenkins-!-color-success-color">${%Do}</th>
+          <th class="jenkins-!-color-error-color">${%Don't}</th>
         </tr>
       </thead>
       <tbody>
@@ -96,10 +96,13 @@
       <code class="sample-remote language-xml" data-sample="symbol-size.jelly" />
     </pre>
 
-    <a href="https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols"
-       class="jdl-paragraph jdl-link">
-      View the complete list of symbols available to use on GitHub
-    </a>
+    <span>
+      <a href="https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols"
+         target="_blank" class="jdl-paragraph jdl-link">
+        ${%View the complete list of Jenkins Symbols on GitHub}
+        <l:icon src="symbol-external plugin-design-library" />
+      </a>
+    </span>
 
     <h2 class="jdl-heading">${%customSymbols}</h2>
     <p class="jdl-paragraph">${%customSymbols.description.1}</p>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -32,28 +32,28 @@
       </div>
     </div>
 
-    <p class="jdl-leading-paragraph">${%title}</p>
+    <p class="jdl-leading-paragraph">${%leadParagraph}</p>
 
     <hr/>
 
     <table class="jdl-dos-donts">
       <thead>
         <tr>
-          <th class="jenkins-!-color-success-color">${%Do}</th>
-          <th class="jenkins-!-color-error-color">${%Don't}</th>
+          <th class="jenkins-!-color-success-color">${%do}</th>
+          <th class="jenkins-!-color-error-color">${%dont}</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td>Symbols should be used to help a user recognise what a task does at a glance</td>
-          <td>Don't use custom symbols that aren't consistent with Jenkins</td>
+          <td>${%do.1}</td>
+          <td>${%dont.1}</td>
         </tr>
         <tr>
-          <td>They should be recognisable and relevant, e.g. <l:icon src="symbol-lock-closed" /> for credentials</td>
-          <td>Don't add symbols to headings, they just create visual clutter</td>
+          <td>${%do.2}<l:icon src="symbol-lock-closed" />${%do.2Continued}</td>
+          <td>${%dont.2}</td>
         </tr>
         <tr>
-          <td>Use a tooltip on the symbol if there isn't any accompanying text</td>
+          <td>${%do.3}</td>
         </tr>
       </tbody>
     </table>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -63,7 +63,7 @@
     <p class="jdl-paragraph">${%usage.1}</p>
 
     <div class="jdl-symbols__symbol-container">
-      <l:icon src="symbol-search" />
+      <l:icon src="symbol-search" class="jdl-symbols__symbol" />
     </div>
     <pre class="jdl-symbols__symbol-code">
       <code class="sample-remote language-xml" data-sample="symbol.jelly" />
@@ -71,7 +71,7 @@
 
     <p class="jdl-paragraph">${%usage.2}</p>
     <div class="jdl-symbols__symbol-container">
-      <l:icon src="symbol-jenkins" tooltip="Howdy" />
+      <l:icon src="symbol-jenkins" tooltip="Howdy" class="jdl-symbols__symbol" />
     </div>
     <pre class="jdl-symbols__symbol-code">
       <code class="sample-remote language-xml" data-sample="symbol-tooltip.jelly" />
@@ -79,7 +79,7 @@
 
     <p class="jdl-paragraph">${%usage.3}</p>
     <div class="jdl-symbols__symbol-container">
-      <l:icon src="symbol-rss" class="spin" />
+      <l:icon src="symbol-rss" class="jdl-symbols__symbol spin" />
     </div>
     <pre class="jdl-symbols__symbol-code">
       <code class="sample-remote language-xml" data-sample="symbol-classes.jelly" />

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -1,33 +1,34 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="/lib/samples" xmlns:l="/lib/layout">
   <s:sample>
+    <j:set var="icons" value="${it.symbols}" />
     <div class="jdl-symbols__masthead">
       <div>
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
       </div>
       <div>
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
         <l:icon src="symbol-symbols plugin-design-library" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
       </div>
       <div>
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
-        <l:icon src="${it.symbol}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
+        <l:icon src="symbol-${icons.pop()}" />
       </div>
     </div>
 

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -45,11 +45,11 @@
       <tbody>
         <tr>
           <td>Symbols should be used to help a user recognise what a task does at a glance</td>
-          <td>Don't add symbols to headings</td>
+          <td>Don't use custom symbols that aren't consistent with Jenkins</td>
         </tr>
         <tr>
           <td>They should be recognisable and relevant, e.g. <l:icon src="symbol-lock-closed" /> for credentials</td>
-          <td>Dont add symbols to headings</td>
+          <td>Don't add symbols to headings, they just create visual clutter</td>
         </tr>
         <tr>
           <td>Use a tooltip on the symbol if there isn't any accompanying text</td>
@@ -61,35 +61,43 @@
 
     <h2 class="jdl-heading">${%usage.title}</h2>
     <p class="jdl-paragraph">${%usage.1}</p>
-    <p class="icon-md">
+
+    <div class="jdl-symbols__symbol-container">
       <l:icon src="symbol-search" />
-    </p>
-    <pre>
+    </div>
+    <pre class="jdl-symbols__symbol-code">
       <code class="sample-remote language-xml" data-sample="symbol.jelly" />
     </pre>
 
     <p class="jdl-paragraph">${%usage.2}</p>
-    <p class="icon-md">
-      <l:icon src="symbol-search" alt="Search" class="custom-class" />
-    </p>
-    <pre>
-      <code class="sample-remote language-xml" data-sample="symbol-alt.jelly" />
+    <div class="jdl-symbols__symbol-container">
+      <l:icon src="symbol-jenkins" tooltip="Howdy" />
+    </div>
+    <pre class="jdl-symbols__symbol-code">
+      <code class="sample-remote language-xml" data-sample="symbol-tooltip.jelly" />
     </pre>
 
     <p class="jdl-paragraph">${%usage.3}</p>
-
-    <ul style="list-style: none;">
-      <li><span class="icon-sm"><l:icon src="symbol-search" alt="Search" class="custom-class" /></span> icon-sm</li>
-      <li><span class="icon-md"><l:icon src="symbol-search" alt="Search" class="custom-class" /></span> icon-md</li>
-      <li><span class="icon-lg"><l:icon src="symbol-search" alt="Search" class="custom-class" /></span> icon-lg</li>
-      <li><span class="icon-xlg"><l:icon src="symbol-search" alt="Search" class="custom-class" /></span> icon-xlg</li>
-    </ul>
-
-    <pre>
-      <code class="sample-remote language-xml" data-sample="symbol-size.jelly" />
+    <div class="jdl-symbols__symbol-container">
+      <l:icon src="symbol-rss" class="spin" />
+    </div>
+    <pre class="jdl-symbols__symbol-code">
+      <code class="sample-remote language-xml" data-sample="symbol-classes.jelly" />
     </pre>
 
-    <a href="https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols">
+    <p class="jdl-paragraph">${%usage.4}</p>
+    <div class="jdl-symbols__symbol-container">
+      <l:icon src="symbol-cube" class="icon-sm" />
+      <l:icon src="symbol-cube" class="icon-md" />
+      <l:icon src="symbol-cube" class="icon-lg" />
+      <l:icon src="symbol-cube" class="icon-xlg" />
+    </div>
+    <pre class="jdl-symbols__symbol-code">
+      <code class="sample-remote language-xml" data-sample="symbol-alt.jelly" />
+    </pre>
+
+    <a href="https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols"
+       class="jdl-paragraph jdl-link">
       View the complete list of symbols available to use on GitHub
     </a>
 
@@ -102,12 +110,12 @@
       <code class="sample-remote language-xml" data-sample="symbol-plugin.jelly"/>
     </pre>
 
-    ${%customSymbols.information}
-    <ul>
+    <p class="jdl-paragraph">${%customSymbols.information}</p>
+    <ul class="jdl-list">
       <li>symbolName - ${%customSymbols.symbolName}</li>
       <li>yourArtifactId - ${%customSymbols.artifactId}</li>
     </ul>
 
-    <p>${%customSymbols.artifactId.description}</p>
+    <p class="jdl-paragraph">${%customSymbols.artifactId.description}</p>
   </s:sample>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.properties
@@ -1,9 +1,14 @@
-title=Jenkins Symbols are an extensive and consistent collection of icons for use in Jenkins and plugins. \
+leadParagraph=Jenkins Symbols are an extensive and consistent collection of icons for use in Jenkins and plugins. \
 Symbols are intended to be used everywhere a traditional icon would be used, such as in the sidebar, in buttons and in tables. \
 Symbols are scalable, support different weights and adapt to the user's theme.
-description=Symbols should be used to help a user recognise what a task does at a glance. This means they should be easily \
-recognisable and relevant to the task, e.g. a padlock for credentials. \
-Don't add symbols to headings, they are distracting, often look out of place and do nothing to help the user.
+do=Do
+dont=Don''t
+do.1=Symbols should be used to help a user recognise what a task does at a glance
+do.2=They should be recognisable and relevant, e.g.\u0020
+do.2Continued=\u0020for credentials
+do.3=Use a tooltip on the symbol if there isn't any accompanying text
+dont.1=Don''t use custom symbols that aren't consistent with Jenkins
+dont.2=Don''t add symbols to headings, they just create visual clutter
 usage.title=Using Symbols
 usage.1=Using symbols in your view is simple. Use the existing <code>icon</code> component and set the <code>src</code> value to the symbol you want, prefixed with <code>"symbol-"</code>.
 usage.2=Symbols can also display tooltips:

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.properties
@@ -7,7 +7,7 @@ Don't add symbols to headings, they are distracting, often look out of place and
 usage.title=Using Symbols
 usage.1=Using symbols in your view is simple. Use the existing <code>icon</code> component and set the <code>src</code> value to the symbol you want, prefixed with <code>"symbol-"</code>.
 usage.2=Symbols can also display tooltips:
-usage.3=It's possible to customize symbols with custom classes:
+usage.3=It's also possible to customize symbols with custom classes:
 usage.4=You can change the size of the symbol by using one of the sizing classes:
 customSymbols=Custom Symbols
 customSymbols.description.1=Add your symbol to:

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.properties
@@ -5,9 +5,10 @@ description=Symbols should be used to help a user recognise what a task does at 
 recognisable and relevant to the task, e.g. a padlock for credentials. \
 Don't add symbols to headings, they are distracting, often look out of place and do nothing to help the user.
 usage.title=Using Symbols
-usage.1=Using symbols in your view is simple. Use the existing icon component and set the src value to the symbol you want, prefixed with "symbol-".
-usage.2=It's possible to add alt text and custom classes to symbols, for example:
-usage.3=Sizing of the symbol can be achieved by wrapping it in an element such as <code>span</code> \
+usage.1=Using symbols in your view is simple. Use the existing <code>icon</code> component and set the <code>src</code> value to the symbol you want, prefixed with <code>"symbol-"</code>.
+usage.2=Symbols can also display tooltips, for example:
+usage.3=It's possible to customize symbols with custom classes, for example:
+usage.4=Sizing of the symbol can be achieved by wrapping it in an element such as <code>span</code> \
 with a class of <code>icon-size</code> where size is one of:
 customSymbols=Custom Symbols
 customSymbols.description.1=Add your symbol to:

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.properties
@@ -6,10 +6,9 @@ recognisable and relevant to the task, e.g. a padlock for credentials. \
 Don't add symbols to headings, they are distracting, often look out of place and do nothing to help the user.
 usage.title=Using Symbols
 usage.1=Using symbols in your view is simple. Use the existing <code>icon</code> component and set the <code>src</code> value to the symbol you want, prefixed with <code>"symbol-"</code>.
-usage.2=Symbols can also display tooltips, for example:
-usage.3=It's possible to customize symbols with custom classes, for example:
-usage.4=Sizing of the symbol can be achieved by wrapping it in an element such as <code>span</code> \
-with a class of <code>icon-size</code> where size is one of:
+usage.2=Symbols can also display tooltips:
+usage.3=It's possible to customize symbols with custom classes:
+usage.4=You can change the size of the symbol by using one of the sizing classes:
 customSymbols=Custom Symbols
 customSymbols.description.1=Add your symbol to:
 customSymbols.description.2=Reference it with:

--- a/src/main/resources/scss/abstracts/_overrides.scss
+++ b/src/main/resources/scss/abstracts/_overrides.scss
@@ -37,6 +37,35 @@ pre {
   code {
     font-size: 1rem !important;
     text-shadow: none !important;
+    color: var(--text-color) !important;
+
+    .token.cdata, .token.comment, .token.doctype, .token.prolog {
+      color: var(--text-color-secondary) !important;
+    }
+
+    .token.punctuation {
+      color: var(--text-color-secondary) !important;
+    }
+
+    .token.boolean, .token.constant, .token.deleted, .token.number, .token.property, .token.symbol, .token.tag {
+      color: var(--pink) !important;
+    }
+
+    .token.attr-name, .token.builtin, .token.char, .token.inserted, .token.selector, .token.string {
+      color: var(--green) !important;
+    }
+
+    .language-css .token.string, .style .token.string, .token.entity, .token.operator, .token.url {
+      color: var(--brown) !important;
+    }
+
+    .token.atrule, .token.attr-value, .token.keyword {
+      color: var(--cyan) !important;
+    }
+
+    .token.class-name, .token.function {
+      color: var(--purple) !important;
+    }
   }
 }
 

--- a/src/main/resources/scss/abstracts/_overrides.scss
+++ b/src/main/resources/scss/abstracts/_overrides.scss
@@ -1,3 +1,7 @@
+:root {
+  --jdl-spacing: 2rem;
+}
+
 #main-panel {
   display: flex !important;
   flex-direction: column;
@@ -12,5 +16,15 @@
 }
 
 pre {
-  margin: 0 0 var(--section-padding) 0 !important;
+  margin: 0 0 var(--jdl-spacing) 0 !important;
+}
+
+hr {
+  display: inline-block;
+  width: 100%;
+  border: none;
+  height: 2px;
+  background: currentColor;
+  margin: 0 0 var(--jdl-spacing) 0;
+  opacity: 0.1;
 }

--- a/src/main/resources/scss/abstracts/_overrides.scss
+++ b/src/main/resources/scss/abstracts/_overrides.scss
@@ -15,8 +15,33 @@
   }
 }
 
+// Remove when code blocks follows user's theme
+// https://github.com/jenkinsci/design-library-plugin/issues/68
 pre {
+  position: relative;
   margin: 0 0 var(--jdl-spacing) 0 !important;
+  padding: calc(var(--jdl-spacing) / 2) !important;
+  background: transparent !important;
+  z-index: 0;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--text-color);
+    border-radius: inherit;
+    opacity: 0.05;
+    z-index: -1;
+  }
+
+  code {
+    font-size: 1rem !important;
+    text-shadow: none !important;
+  }
+}
+
+code {
+  font-family: var(--font-family-mono) !important;
 }
 
 hr {

--- a/src/main/resources/scss/abstracts/_symbols.scss
+++ b/src/main/resources/scss/abstracts/_symbols.scss
@@ -1,0 +1,2 @@
+$check: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='55' d='M416 128L192 384l-96-96'/%3E%3C/svg%3E");
+$cross: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='45' d='M368 368L144 144M368 144L144 368'/%3E%3C/svg%3E");

--- a/src/main/resources/scss/abstracts/_typography.scss
+++ b/src/main/resources/scss/abstracts/_typography.scss
@@ -26,6 +26,13 @@
   }
 }
 
+.jdl-list {
+  font-size: 1.1rem;
+  font-weight: 500;
+  margin: 0 0 var(--jdl-spacing) 0;
+  line-height: 1.66;
+}
+
 .jdl-important-point {
   position: relative;
   font-size: 1rem;

--- a/src/main/resources/scss/abstracts/_typography.scss
+++ b/src/main/resources/scss/abstracts/_typography.scss
@@ -51,3 +51,20 @@
     margin-right: 1ch;
   }
 }
+
+.jdl-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 1ch;
+  text-decoration-thickness: 2px;
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+
+    * {
+      stroke-width: 45px;
+    }
+  }
+}

--- a/src/main/resources/scss/abstracts/_typography.scss
+++ b/src/main/resources/scss/abstracts/_typography.scss
@@ -1,21 +1,34 @@
 .jdl-heading {
   font-weight: 600;
   font-size: 1.2rem;
-  margin: calc(var(--section-padding) / 2) 0;
+  margin: calc(var(--jdl-spacing) / 2) 0;
 }
 
 .jdl-leading-paragraph {
-  font-size: 1rem;
-  font-weight: 500;
-  margin: 0 0 var(--section-padding) 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0 0 var(--jdl-spacing) 0;
+  line-height: 1.66;
 
   & + & {
-    margin-top: calc((var(--section-padding) / 2) * -1);
+    margin-top: calc((var(--jdl-spacing) / 2) * -1);
+  }
+}
+
+.jdl-paragraph {
+  font-size: 1.1rem;
+  font-weight: 500;
+  margin: 0 0 var(--jdl-spacing) 0;
+  line-height: 1.66;
+
+  & + & {
+    margin-top: calc((var(--jdl-spacing) / 2) * -1);
   }
 }
 
 .jdl-important-point {
   position: relative;
+  font-size: 1rem;
   padding-left: calc(1.5rem + 1ch);
 
   &::before {

--- a/src/main/resources/scss/components/_component-sample.scss
+++ b/src/main/resources/scss/components/_component-sample.scss
@@ -3,10 +3,10 @@
   display: flex;
   align-items: flex-start;
   flex-direction: column;
-  gap: calc(var(--section-padding) / 2);
-  padding: calc(var(--section-padding) / 2);
+  gap: calc(var(--jdl-spacing) / 2);
+  padding: calc(var(--jdl-spacing) / 2);
   border-radius: 10px;
-  margin-bottom: var(--section-padding);
+  margin-bottom: var(--jdl-spacing);
   z-index: 0;
 
   &::before {

--- a/src/main/resources/scss/components/_dos-donts.scss
+++ b/src/main/resources/scss/components/_dos-donts.scss
@@ -1,0 +1,83 @@
+@use "../abstracts/symbols";
+
+.jdl-dos-donts {
+  margin-bottom: var(--jdl-spacing);
+  border-collapse: collapse;
+  border-style: hidden;
+
+  th, td {
+    width: 50%;
+    padding: 0;
+    border-top: 1rem solid transparent;
+    border-left: 3rem solid transparent;
+  }
+
+  svg {
+    width: 1.2rem;
+    height: 1.2rem;
+    margin-top: 4px;
+
+    * {
+      stroke-width: 55px !important;
+    }
+  }
+
+  thead {
+    th {
+      font-weight: 600;
+      font-size: 1rem;
+      text-align: left;
+      opacity: 0.75;
+    }
+  }
+
+  tbody {
+    td {
+      position: relative;
+      font-size: 1.1rem;
+      font-weight: 600;
+      line-height: 1.66;
+      padding-left: calc(2rem + 1.5ch);
+
+      &::before,
+      &::after {
+        content: "";
+        position: absolute;
+        display: inline-block;
+        width: 2rem;
+        height: 2rem;
+        top: 0;
+        left: 0;
+        border-radius: 100%;
+      }
+
+      &::after {
+        background: var(--background);
+        mask-repeat: no-repeat;
+        mask-position: center;
+      }
+
+      &:first-of-type {
+        &::before {
+          background: var(--success-color, var(--green));
+        }
+
+        &::after {
+          mask-image: symbols.$check;
+          mask-size: 55%;
+        }
+      }
+
+      &:not(:first-of-type) {
+        &::before {
+          background: var(--error-color, var(--red));
+        }
+
+        &::after {
+          mask-image: symbols.$cross;
+          mask-size: 60%;
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/scss/components/_index.scss
+++ b/src/main/resources/scss/components/_index.scss
@@ -1,2 +1,3 @@
 @use "component-sample";
+@use "dos-donts";
 @use "source-block";

--- a/src/main/resources/scss/components/_source-block.scss
+++ b/src/main/resources/scss/components/_source-block.scss
@@ -1,7 +1,7 @@
 .app-code {
   word-wrap: break-word;
-  padding: calc(var(--section-padding) / 2);
+  padding: calc(var(--jdl-spacing) / 2);
   border-radius: 10px;
   background: rgba(100, 100, 100, 0.05);
-  margin-bottom: var(--section-padding);
+  margin-bottom: var(--jdl-spacing);
 }

--- a/src/main/resources/scss/pages/_index.scss
+++ b/src/main/resources/scss/pages/_index.scss
@@ -1,3 +1,4 @@
 @use "colors";
 @use "home";
 @use "spacing";
+@use "symbols";

--- a/src/main/resources/scss/pages/_symbols.scss
+++ b/src/main/resources/scss/pages/_symbols.scss
@@ -148,11 +148,11 @@ $delay: 0.1;
     mask-size: 3rem;
     opacity: 0.5;
   }
+}
 
-  svg {
-    width: 2rem;
-    height: 2rem;
-  }
+.jdl-symbols__symbol {
+  width: 2rem;
+  height: 2rem;
 }
 
 .jdl-symbols__symbol-code {
@@ -163,11 +163,12 @@ $delay: 0.1;
 }
 
 .spin {
-  animation: spin var(--elastic-transition) infinite;
+  animation: spin 2.5s cubic-bezier(0, 0.68, 0.5, 1.2) infinite;
 }
 
 @keyframes spin {
-  from {
-    transform: rotate(-360deg);
+  30%,
+  100% {
+    transform: rotate(360deg);
   }
 }

--- a/src/main/resources/scss/pages/_symbols.scss
+++ b/src/main/resources/scss/pages/_symbols.scss
@@ -110,3 +110,64 @@ $delay: 0.1;
     filter: blur(40px) brightness(2);
   }
 }
+
+.jdl-symbols__symbol-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 4 / 1;
+  margin-bottom: var(--jdl-spacing);
+  z-index: 0;
+  gap: 1rem;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(at 40% 20%, hsl(312, 42%, 60%) 0, transparent 50%),
+    radial-gradient(at 80% 0%, hsl(11, 100%, 56%) 0, transparent 50%),
+    radial-gradient(at 0% 50%, hsl(354, 64%, 72%) 0, transparent 50%),
+    radial-gradient(at 80% 50%, hsl(319, 66%, 64%) 0, transparent 50%),
+    radial-gradient(at 0% 100%, hsl(264, 37%, 59%) 0, transparent 50%),
+    radial-gradient(at 80% 100%, hsl(342, 55%, 41%) 0, transparent 50%),
+    radial-gradient(at 0% 0%, hsla(343, 100%, 76%, 1) 0, transparent 50%);
+    border-radius: 10px 10px 0 0;
+    z-index: -1;
+  }
+
+  &::before {
+    opacity: 0.05;
+  }
+
+  &::after {
+    mask-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg width='300px' height='300px' viewBox='0 0 300 300' version='1.1' xmlns='http://www.w3.org/2000/svg'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Ccircle id='Oval' fill='%23D8D8D8' cx='300' cy='0' r='10'%3E%3C/circle%3E%3Ccircle id='Oval' fill='%23D8D8D8' cx='0' cy='0' r='10'%3E%3C/circle%3E%3Ccircle id='Oval' fill='%23D8D8D8' cx='0' cy='300' r='10'%3E%3C/circle%3E%3Ccircle id='Oval' fill='%23D8D8D8' cx='300' cy='300' r='10'%3E%3C/circle%3E%3C/g%3E%3C/svg%3E");
+    mask-position: center;
+    mask-size: 3rem;
+    opacity: 0.5;
+  }
+
+  svg {
+    width: 2rem;
+    height: 2rem;
+  }
+}
+
+.jdl-symbols__symbol-code {
+  margin-top: calc(var(--jdl-spacing) * -1) !important;
+  padding: calc(var(--jdl-spacing) / 2) !important;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.spin {
+  animation: spin var(--elastic-transition) infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(-360deg);
+  }
+}

--- a/src/main/resources/scss/pages/_symbols.scss
+++ b/src/main/resources/scss/pages/_symbols.scss
@@ -157,7 +157,6 @@ $delay: 0.1;
 
 .jdl-symbols__symbol-code {
   margin-top: calc(var(--jdl-spacing) * -1) !important;
-  padding: calc(var(--jdl-spacing) / 2) !important;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }

--- a/src/main/resources/scss/pages/_symbols.scss
+++ b/src/main/resources/scss/pages/_symbols.scss
@@ -1,0 +1,112 @@
+$delay: 0.1;
+
+.jdl-symbols__masthead {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  grid-gap: 1fr;
+  align-items: center;
+  justify-items: center;
+  width: 100%;
+  aspect-ratio: 3 / 1;
+  z-index: 0;
+  margin-bottom: var(--jdl-spacing);
+  padding: 1rem 0;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: 10px;
+    overflow: hidden;
+
+    @media (max-width: 970px) {
+      --sidebar-width: 0;
+      --content-width: 100%;
+      background-size: 100%;
+    }
+
+    background-position-x: calc(var(--sidebar-width) + ((100vw - (var(--content-width) + var(--sidebar-width))) / 2));
+  }
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background-image: radial-gradient(at 40% 20%, hsl(312, 42%, 60%) 0, transparent 50%),
+    radial-gradient(at 80% 0%, hsl(11, 100%, 56%) 0, transparent 50%),
+    radial-gradient(at 0% 50%, hsl(354, 64%, 72%) 0, transparent 50%),
+    radial-gradient(at 80% 50%, hsl(319, 66%, 64%) 0, transparent 50%),
+    radial-gradient(at 0% 100%, hsl(264, 37%, 59%) 0, transparent 50%),
+    radial-gradient(at 80% 100%, hsl(342, 55%, 41%) 0, transparent 50%),
+    radial-gradient(at 0% 0%, hsla(343, 100%, 76%, 1) 0, transparent 50%);
+    animation: rotate-colors 10s linear infinite;
+  }
+  .app-card__preview::after {
+    background-image: radial-gradient(at 80% 0%, hsla(13, 100%, 56%, 1) 0, transparent 50%),
+    radial-gradient(at 0% 50%, hsl(31, 100%, 80%) 0, transparent 50%),
+    radial-gradient(at 80% 50%, hsla(164, 100%, 76%, 1) 0, transparent 50%),
+    radial-gradient(at 0% 100%, hsl(206, 60%, 57%) 0, transparent 50%),
+    radial-gradient(at 80% 100%, hsl(146, 64%, 79%) 0, transparent 50%),
+    radial-gradient(at 0% 0%, hsla(167, 100%, 76%, 1) 0, transparent 50%);
+    animation: rotate-colors-2 10s linear infinite;
+  }
+
+  div {
+    display: contents;
+
+    @for $i from 0 through 3 {
+      &:nth-of-type(#{$i}) {
+        --animation-delay: #{$i * $delay}s;
+      }
+    }
+  }
+
+  svg {
+    max-width: min(5vw, 2.5rem);
+    max-height: min(5vw, 2.5rem);
+    width: min(5vw, 2.5rem);
+    opacity: 0.75;
+    mix-blend-mode: overlay;
+    animation: scale-in-symbol var(--elastic-transition) calc(var(--animation-delay) + var(--animation-svg-delay))  both;
+
+    @for $i from 1 through 7 {
+      &:nth-of-type(#{$i}) {
+        --animation-svg-delay: #{$i * $delay}s;
+      }
+    }
+  }
+
+  div:nth-of-type(2) {
+    svg {
+      &:nth-of-type(4) {
+        max-width: min(6vw, 6rem);
+        max-height: min(6vw, 6rem);
+        width: min(6vw, 6rem);
+        opacity: 1;
+        mix-blend-mode: normal;
+        animation-name: scale-in-symbol-main;
+      }
+    }
+  }
+}
+
+@keyframes scale-in-symbol {
+  from {
+    transform: scale(0);
+    opacity: 0;
+    filter: blur(20px) brightness(2);
+  }
+}
+
+@keyframes scale-in-symbol-main {
+  from {
+    transform: scale(0) rotate(-20deg);
+    opacity: 0;
+    filter: blur(40px) brightness(2);
+  }
+}

--- a/src/main/webapp/Symbols/symbol-alt.jelly
+++ b/src/main/webapp/Symbols/symbol-alt.jelly
@@ -1,1 +1,0 @@
-<l:icon src="symbol-search" alt="Search" class="custom-class" />

--- a/src/main/webapp/Symbols/symbol-classes.jelly
+++ b/src/main/webapp/Symbols/symbol-classes.jelly
@@ -1,0 +1,1 @@
+<l:icon src="symbol-rss" class="spin" />

--- a/src/main/webapp/Symbols/symbol-size.jelly
+++ b/src/main/webapp/Symbols/symbol-size.jelly
@@ -1,3 +1,4 @@
-<span class="icon-md">
-  <l:icon src="symbol-search" />
-</span>
+<l:icon src="symbol-cube" class="icon-sm" />
+<l:icon src="symbol-cube" class="icon-md" />
+<l:icon src="symbol-cube" class="icon-lg" />
+<l:icon src="symbol-cube" class="icon-xlg" />

--- a/src/main/webapp/Symbols/symbol-tooltip.jelly
+++ b/src/main/webapp/Symbols/symbol-tooltip.jelly
@@ -1,0 +1,1 @@
+<l:icon src="symbol-jenkins" tooltip="Howdy" />


### PR DESCRIPTION
![symbols](https://user-images.githubusercontent.com/43062514/169163587-76e96125-b575-41e6-83bc-7fe6f9ada2f7.png)

Felt that this page could do with a bit of love, also enabled some thinking/building of components to use across the library in the future.

**TODO**
- [x] Classes aren't working on Symbols, this'll require a Jenkins fix I imagine
- [x] I18N
- [x] Add more symbols to the Java method so that the masthead doesn't repeat symbols

Theme aware code blocks would be nice (https://github.com/jenkinsci/design-library-plugin/issues/68)

<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/67"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

