### PR TITLE
Remove workaround for intellij not being ready in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@ tasks:
       # without host being `0.0.0.0` redirects will go to localhost ignoring the forwarded values for some reason
       mvn hpi:run -Dhost=0.0.0.0
     name: Run
-  - command: gp await-port 63342 && gp await-port 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins/
+  - command: gp await-port 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins/
     name: Preview
 
 github:


### PR DESCRIPTION
see https://github.com/jenkinsci/jenkins/pull/6590#discussion_r883672395


<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/75"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

