### PR TITLE
draft: Add search to Design Library

### DIFF
--- a/src/main/java/io/jenkins/plugins/designlibrary/Root.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Root.java
@@ -2,11 +2,7 @@ package io.jenkins.plugins.designlibrary;
 
 import hudson.Extension;
 import hudson.model.RootAction;
-import hudson.util.HttpResponses;
 import net.sf.json.JSONArray;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
 import java.util.List;
 
@@ -38,12 +34,11 @@ public class Root implements RootAction {
         return null;
     }
 
-    public HttpResponse doSearch(StaplerRequest request, StaplerResponse response) {
-        final String query = request.getParameter("query");
-        return HttpResponses.okJSON(JSONArray.fromObject(SearchHelper.getSearchResults(query, request, response)));
-    }
-
     public List<UISample> getAll() {
         return UISample.getAll();
+    }
+
+    public JSONArray getSearch() {
+        return UISample.getSearch();
     }
 }

--- a/src/main/java/io/jenkins/plugins/designlibrary/Root.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Root.java
@@ -3,18 +3,12 @@ package io.jenkins.plugins.designlibrary;
 import hudson.Extension;
 import hudson.model.RootAction;
 import hudson.util.HttpResponses;
-import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
-import org.apache.commons.jelly.JellyException;
-import org.jenkins.ui.icon.IconSet;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Entry point to all the UI samples.
@@ -44,76 +38,9 @@ public class Root implements RootAction {
         return null;
     }
 
-    public static class SearchResult {
-        private String icon;
-        private String title;
-        private String url;
-        private List<SearchResult> children;
-
-        public SearchResult() {
-        }
-
-        public SearchResult(String title, String url) {
-            this.title = title;
-            this.url = url;
-        }
-
-        public String getIcon() {
-            return icon;
-        }
-
-        public void setIcon(String icon) {
-            this.icon = icon;
-        }
-
-        public String getTitle() {
-            return title;
-        }
-
-        public void setTitle(String title) {
-            this.title = title;
-        }
-
-        public String getUrl() {
-            return url;
-        }
-
-        public void setUrl(String url) {
-            this.url = url;
-        }
-
-        public List<SearchResult> getChildren() {
-            return children;
-        }
-
-        public void setChildren(List<SearchResult> children) {
-            this.children = children;
-        }
-    }
-
-    public HttpResponse doSearch(StaplerRequest req, StaplerResponse response) {
-        final StaplerRequest request = Stapler.getCurrentRequest();
+    public HttpResponse doSearch(StaplerRequest request, StaplerResponse response) {
         final String query = request.getParameter("query");
-
-        List<SearchResult> searchResults = getAll().stream()
-                .filter(sample -> sample.getDisplayName().toLowerCase().contains(query.toLowerCase()))
-                .limit(5)
-                .map(sample -> {
-            SearchResult searchResult = new SearchResult();
-            searchResult.setIcon(IconSet.getSymbol(sample.getIconFileName().substring(7),
-                    "", "", "", "design-library", ""));
-            searchResult.setTitle(sample.getDisplayName());
-            searchResult.setUrl(Jenkins.get().getRootUrl() + "design-library/" + sample.getUrlName());
-                    try {
-                        searchResult.setChildren(sample.getHeadings(request, response));
-                    } catch (JellyException | IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                    return searchResult;
-        })
-                .collect(Collectors.toList());
-
-        return HttpResponses.okJSON(JSONArray.fromObject(searchResults));
+        return HttpResponses.okJSON(JSONArray.fromObject(SearchHelper.getSearchResults(query, request, response)));
     }
 
     public List<UISample> getAll() {

--- a/src/main/java/io/jenkins/plugins/designlibrary/Root.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Root.java
@@ -2,11 +2,19 @@ package io.jenkins.plugins.designlibrary;
 
 import hudson.Extension;
 import hudson.model.RootAction;
+import hudson.util.HttpResponses;
+import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithContextMenu;
+import net.sf.json.JSONArray;
+import org.jenkins.ui.icon.IconSet;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Entry point to all the UI samples.
@@ -34,6 +42,85 @@ public class Root implements RootAction, ModelObjectWithContextMenu {
                 return ui;
         }
         return null;
+    }
+
+    public static class SearchResult {
+        private String icon;
+        private String title;
+        private String description;
+        private String url;
+        private List<SearchResult> children;
+
+        public SearchResult() {
+        }
+
+        public SearchResult(String title, String description, String url) {
+            this.title = title;
+            this.description = description;
+            this.url = url;
+        }
+
+        public String getIcon() {
+            return icon;
+        }
+
+        public void setIcon(String icon) {
+            this.icon = icon;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public List<SearchResult> getChildren() {
+            return children;
+        }
+
+        public void setChildren(List<SearchResult> children) {
+            this.children = children;
+        }
+    }
+
+    public HttpResponse doSearch() {
+        final StaplerRequest request = Stapler.getCurrentRequest();
+        final String query = request.getParameter("query");
+
+        List<SearchResult> searchResults = getAll().stream()
+                .filter(sample -> sample.getDisplayName().toLowerCase().contains(query.toLowerCase()))
+                .limit(5)
+                .map(sample -> {
+            SearchResult searchResult = new SearchResult();
+            searchResult.setIcon(IconSet.getSymbol(sample.getIconFileName().substring(7),
+                    "", "", "", "design-library", ""));
+            searchResult.setTitle(sample.getDisplayName());
+            searchResult.setUrl(Jenkins.get().getRootUrl() + "design-library/" + sample.getUrlName());
+            searchResult.setChildren(Collections.singletonList(
+                    new SearchResult("Tropic Morning News", "Hello world", "")));
+            return searchResult;
+        })
+                .collect(Collectors.toList());
+
+        return HttpResponses.okJSON(JSONArray.fromObject(searchResults));
     }
 
     public List<UISample> getAll() {

--- a/src/main/java/io/jenkins/plugins/designlibrary/SearchHelper.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/SearchHelper.java
@@ -1,0 +1,142 @@
+package io.jenkins.plugins.designlibrary;
+
+import hudson.Functions;
+import jenkins.model.Jenkins;
+import org.apache.commons.jelly.JellyContext;
+import org.apache.commons.jelly.JellyException;
+import org.apache.commons.jelly.JellyTagException;
+import org.apache.commons.jelly.Script;
+import org.apache.commons.jelly.XMLOutput;
+import org.jenkins.ui.icon.IconSet;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.WebApp;
+import org.kohsuke.stapler.jelly.DefaultScriptInvoker;
+import org.kohsuke.stapler.jelly.JellyClassTearOff;
+import org.kohsuke.stapler.jelly.JellyFacet;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class SearchHelper {
+
+	private static final Map<UISample, List<SearchResult>> cachedHeadings = new HashMap<>();
+
+	public static List<SearchResult> getSearchResults(String query, StaplerRequest request, StaplerResponse response) {
+		return UISample.getAll().stream()
+				.map(sample -> {
+					SearchResult searchResult = new SearchResult();
+					searchResult.setIcon(IconSet.getSymbol(sample.getIconFileName().substring(7),
+							"", "", "", "design-library", ""));
+					searchResult.setTitle(sample.getDisplayName());
+					searchResult.setUrl(Jenkins.get().getRootUrl() + "design-library/" + sample.getUrlName());
+					try {
+						searchResult.setChildren(SearchHelper.getHeadingsFromView(sample, request, response));
+					} catch (RuntimeException | JellyException | IOException e) {
+						throw new RuntimeException(e);
+					}
+					return searchResult;
+				})
+				.filter(result -> result.getTitle().toLowerCase().contains(query.toLowerCase()) ||
+						result.getChildren().stream().anyMatch(e -> e.getTitle().toLowerCase().contains(query.toLowerCase())))
+				.limit(5)
+				.collect(Collectors.toList());
+	}
+
+	private static List<SearchResult> getHeadingsFromView(UISample uiSample, StaplerRequest request, StaplerResponse response) throws JellyException, IOException {
+		if (cachedHeadings.containsKey(uiSample)) {
+			return cachedHeadings.get(uiSample);
+		}
+
+		WebApp webApp = WebApp.getCurrent();
+		final Script s = webApp.getMetaClass(uiSample).getTearOff(JellyClassTearOff.class).findScript("index");
+		List<SearchResult> searchResults = new ArrayList<>();
+
+		if (s != null) {
+			JellyFacet facet = webApp.getFacet(JellyFacet.class);
+			request.setAttribute("mode", "main-panel");
+			DefaultScriptInvoker dsi = new DefaultScriptInvoker();
+			StringWriter sw = new StringWriter();
+			XMLOutput xml = dsi.createXMLOutput(sw, true);
+
+			facet.scriptInvoker.invokeScript(request, response, new Script() {
+				@Override
+				public Script compile() {
+					return this;
+				}
+
+				@Override
+				public void run(JellyContext context, XMLOutput output) throws JellyTagException {
+					Functions.initPageVariables(context);
+					s.run(context, output);
+				}
+			}, uiSample, xml);
+
+			final Pattern pattern = Pattern.compile("<h2.*?id=\"(.*?)\".*?>(.*?)</h2>", Pattern.MULTILINE);
+			final Matcher matcher = pattern.matcher(sw.toString());
+
+			while (matcher.find()) {
+				searchResults.add(new SearchResult(matcher.group(2),
+						Jenkins.get().getRootUrl() + "design-library/" + uiSample.getUrlName() + "#" + matcher.group(1)));
+			}
+		}
+
+		cachedHeadings.put(uiSample, searchResults);
+
+		return searchResults;
+	}
+
+	public static class SearchResult {
+		private String icon;
+		private String title;
+		private String url;
+		private List<SearchResult> children;
+
+		public SearchResult() {
+		}
+
+		public SearchResult(String title, String url) {
+			this.title = title;
+			this.url = url;
+		}
+
+		public String getIcon() {
+			return icon;
+		}
+
+		public void setIcon(String icon) {
+			this.icon = icon;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+
+		public String getUrl() {
+			return url;
+		}
+
+		public void setUrl(String url) {
+			this.url = url;
+		}
+
+		public List<SearchResult> getChildren() {
+			return children;
+		}
+
+		public void setChildren(List<SearchResult> children) {
+			this.children = children;
+		}
+	}
+}

--- a/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
@@ -1,35 +1,17 @@
 package io.jenkins.plugins.designlibrary;
 
 import hudson.ExtensionPoint;
-import hudson.Functions;
 import hudson.model.Action;
 import hudson.model.Describable;
 import jenkins.model.Jenkins;
-import org.apache.commons.jelly.JellyContext;
-import org.apache.commons.jelly.JellyException;
-import org.apache.commons.jelly.JellyTagException;
-import org.apache.commons.jelly.Script;
-import org.apache.commons.jelly.XMLOutput;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.WebApp;
-import org.kohsuke.stapler.jelly.DefaultScriptInvoker;
-import org.kohsuke.stapler.jelly.JellyClassTearOff;
-import org.kohsuke.stapler.jelly.JellyFacet;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public abstract class UISample implements ExtensionPoint, Action, Describable<UISample> {
-    public static List<Root.SearchResult> headings = new ArrayList<>();
-
     public String getIconFileName() {
         return "symbol-sample";
     }
@@ -67,45 +49,5 @@ public abstract class UISample implements ExtensionPoint, Action, Describable<UI
         } catch (IndexOutOfBoundsException e) {
             return null;
         }
-    }
-
-    public List<Root.SearchResult> getHeadings(StaplerRequest request, StaplerResponse response) throws JellyException, IOException {
-        if (headings.size() != 0) {
-            return headings;
-        }
-
-        WebApp webApp = WebApp.getCurrent();
-        final Script s = webApp.getMetaClass(this).getTearOff(JellyClassTearOff.class).findScript("index");
-
-        if (s != null) {
-            JellyFacet facet = webApp.getFacet(JellyFacet.class);
-            request.setAttribute("mode", "main-panel");
-            DefaultScriptInvoker dsi = new DefaultScriptInvoker();
-            StringWriter sw = new StringWriter();
-            XMLOutput xml = dsi.createXMLOutput(sw, true);
-
-            facet.scriptInvoker.invokeScript(request, response, new Script() {
-                @Override
-                public Script compile() {
-                    return this;
-                }
-
-                @Override
-                public void run(JellyContext context, XMLOutput output) throws JellyTagException {
-                    Functions.initPageVariables(context);
-                    s.run(context, output);
-                }
-            }, this, xml);
-
-            final Pattern pattern = Pattern.compile("<h2.*?id=\"(.*?)\".*?>(.*?)</h2>", Pattern.MULTILINE);
-            final Matcher matcher = pattern.matcher(sw.toString());
-
-            while (matcher.find()) {
-                headings.add(new Root.SearchResult(matcher.group(2),
-                        Jenkins.get().getRootUrl() + "design-library/" + getUrlName() + "#" + matcher.group(1)));
-            }
-        }
-
-        return headings;
     }
 }

--- a/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
@@ -4,6 +4,7 @@ import hudson.ExtensionPoint;
 import hudson.model.Action;
 import hudson.model.Describable;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +34,10 @@ public abstract class UISample implements ExtensionPoint, Action, Describable<UI
 
     public static List<UISample> getAll() {
         return new ArrayList<>(Jenkins.get().getExtensionList(UISample.class));
+    }
+
+    public static JSONArray getSearch() {
+        return JSONArray.fromObject(SearchHelper.getSearchResults());
     }
 
     public UISample getPreviousPage() {

--- a/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
@@ -3,13 +3,28 @@ package io.jenkins.plugins.designlibrary;
 import static org.apache.commons.io.IOUtils.copy;
 
 import hudson.ExtensionPoint;
+import hudson.Functions;
 import hudson.model.Action;
+import hudson.model.Actionable;
 import hudson.model.Describable;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import jenkins.model.Jenkins;
+import jenkins.model.ModelObjectWithContextMenu;
+import org.apache.commons.jelly.JellyContext;
+import org.apache.commons.jelly.JellyException;
+import org.apache.commons.jelly.JellyTagException;
+import org.apache.commons.jelly.Script;
+import org.apache.commons.jelly.XMLOutput;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.WebApp;
+import org.kohsuke.stapler.jelly.JellyClassTearOff;
+import org.kohsuke.stapler.jelly.JellyFacet;
+import org.xml.sax.helpers.DefaultHandler;
 
 /**
  * @author Kohsuke Kawaguchi

--- a/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/UISample.java
@@ -1,19 +1,10 @@
 package io.jenkins.plugins.designlibrary;
 
-import static org.apache.commons.io.IOUtils.copy;
-
 import hudson.ExtensionPoint;
 import hudson.Functions;
 import hudson.model.Action;
-import hudson.model.Actionable;
 import hudson.model.Describable;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import jenkins.model.Jenkins;
-import jenkins.model.ModelObjectWithContextMenu;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.JellyTagException;
@@ -22,14 +13,23 @@ import org.apache.commons.jelly.XMLOutput;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.WebApp;
+import org.kohsuke.stapler.jelly.DefaultScriptInvoker;
 import org.kohsuke.stapler.jelly.JellyClassTearOff;
 import org.kohsuke.stapler.jelly.JellyFacet;
-import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public abstract class UISample implements ExtensionPoint, Action, Describable<UISample> {
+    public static List<Root.SearchResult> headings = new ArrayList<>();
+
     public String getIconFileName() {
         return "symbol-sample";
     }
@@ -67,5 +67,45 @@ public abstract class UISample implements ExtensionPoint, Action, Describable<UI
         } catch (IndexOutOfBoundsException e) {
             return null;
         }
+    }
+
+    public List<Root.SearchResult> getHeadings(StaplerRequest request, StaplerResponse response) throws JellyException, IOException {
+        if (headings.size() != 0) {
+            return headings;
+        }
+
+        WebApp webApp = WebApp.getCurrent();
+        final Script s = webApp.getMetaClass(this).getTearOff(JellyClassTearOff.class).findScript("index");
+
+        if (s != null) {
+            JellyFacet facet = webApp.getFacet(JellyFacet.class);
+            request.setAttribute("mode", "main-panel");
+            DefaultScriptInvoker dsi = new DefaultScriptInvoker();
+            StringWriter sw = new StringWriter();
+            XMLOutput xml = dsi.createXMLOutput(sw, true);
+
+            facet.scriptInvoker.invokeScript(request, response, new Script() {
+                @Override
+                public Script compile() {
+                    return this;
+                }
+
+                @Override
+                public void run(JellyContext context, XMLOutput output) throws JellyTagException {
+                    Functions.initPageVariables(context);
+                    s.run(context, output);
+                }
+            }, this, xml);
+
+            final Pattern pattern = Pattern.compile("<h2.*?id=\"(.*?)\".*?>(.*?)</h2>", Pattern.MULTILINE);
+            final Matcher matcher = pattern.matcher(sw.toString());
+
+            while (matcher.find()) {
+                headings.add(new Root.SearchResult(matcher.group(2),
+                        Jenkins.get().getRootUrl() + "design-library/" + getUrlName() + "#" + matcher.group(1)));
+            }
+        }
+
+        return headings;
     }
 }

--- a/src/main/resources/io/jenkins/plugins/designlibrary/AppBar/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/AppBar/index.jelly
@@ -1,10 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="/lib/samples" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <s:sample>
-
-    ${sections.addHeader('hello world')}
-
-    <h2 class="jdl-heading">${%Top app bar}</h2>
+    <h2 id="top-app-bar" class="jdl-heading">${%Top app bar}</h2>
     <div class="jdl-component-sample jdl-component-sample--full-width jdl-component-sample--gridless">
       <div class="jenkins-app-bar jenkins-!-margin-bottom-0">
         <div class="jenkins-app-bar__content">
@@ -24,7 +21,7 @@
     <p class="jdl-paragraph">${%description}</p>
     <s:code language="xml" file="topAppBar.jelly" />
 
-    <h2 class="jdl-heading">${%Bottom app bar}</h2>
+    <h2 id="bottom-app-bar" class="jdl-heading">${%Bottom app bar}</h2>
     <div class="jdl-component-sample jdl-component-sample--full-width jdl-component-sample--gridless">
       <p class="jdl-paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse lobortis accumsan lorem vel maximus. Vestibulum malesuada velit elementum, finibus arcu nec, maximus eros. Donec varius lacus at orci ultrices volutpat. Nulla ex dui, fringilla a sem a, imperdiet auctor enim. Aliquam ipsum orci, volutpat quis porta sit amet, commodo et sem.</p>
       <p class="jdl-paragraph">Maecenas a elit eget est aliquam consectetur dapibus eu nibh. Suspendisse potenti. Fusce tristique nisl ut malesuada sollicitudin. Praesent sed nisl nibh. Etiam tincidunt enim sit amet eleifend maximus. Aenean molestie congue est, eu vehicula ex vulputate nec. Duis commodo, arcu a malesuada facilisis, purus ex imperdiet dolor, nec rhoncus nibh nisi eu ex. Vivamus varius eleifend sollicitudin.</p>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/AppBar/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/AppBar/index.jelly
@@ -1,6 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="/lib/samples" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <s:sample>
+
+    ${sections.addHeader('hello world')}
+
     <h2 class="jdl-heading">${%Top app bar}</h2>
     <div class="jdl-component-sample jdl-component-sample--full-width jdl-component-sample--gridless">
       <div class="jenkins-app-bar jenkins-!-margin-bottom-0">

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.jelly
@@ -74,7 +74,7 @@ THE SOFTWARE.
       <code class="sample-remote language-html" data-sample="symbolButton.jelly"/>
     </pre>
 
-    <h2>${%copy}</h2>
+    <h2 id="copy-button" class="jdl-heading">${%copy}</h2>
     <p>${%copy.description}</p>
     <div class="app-component-sample">
       <l:copyButton message="text copied" text="Here comes the night time" tooltip="Click to copy" />
@@ -89,7 +89,7 @@ THE SOFTWARE.
       <li>message - ${%copy.parameters.message}</li>
     </ul>
 
-    <h2>${%help}</h2>
+    <h2 id="help-button" class="jdl-heading">${%help}</h2>
     <div class="app-component-sample">
       <t:help href="https://www.jenkins.io" tooltip="${%Additional information on buttons}" />
     </div>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.jelly
@@ -58,14 +58,14 @@ THE SOFTWARE.
     <p class="jdl-leading-paragraph jdl-important-point">${%tip-third}</p>
     <p class="jdl-leading-paragraph jdl-important-point">${%tip-fourth}</p>
 
-    <h2 class="jdl-heading">${%Semantics}</h2>
+    <h2 id="semantics" class="jdl-heading">${%Semantics}</h2>
     <ol class="jdl-colors">
       <j:forEach var="item" items="${it.semantics}">
         <local:item item="${item}" />
       </j:forEach>
     </ol>
 
-    <h2 class="jdl-heading">${%Palette}</h2>
+    <h2 id="palette" class="jdl-heading">${%Palette}</h2>
     <ol class="jdl-colors">
       <j:forEach var="item" items="${it.colors}">
         <local:item item="${item}" />

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Root/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Root/index.jelly
@@ -2,6 +2,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:s="/lib/samples">
   <l:layout title="Design Library">
     <st:adjunct includes="io.jenkins.plugins.designlibrary.styles" />
+    <st:adjunct includes="io.jenkins.plugins.designlibrary.search" />
+
     <l:side-panel>
       <s:sidepanel />
     </l:side-panel>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -60,7 +60,7 @@
 
     <hr/>
 
-    <h2 class="jdl-heading">${%usage.title}</h2>
+    <h2 id="using-symbols" class="jdl-heading">${%usage.title}</h2>
     <p class="jdl-paragraph">${%usage.1}</p>
 
     <div class="jdl-component-sample">
@@ -97,7 +97,7 @@
       </a>
     </span>
 
-    <h2 class="jdl-heading">${%customSymbols}</h2>
+    <h2 id="custom-symbols" class="jdl-heading">${%customSymbols}</h2>
     <p class="jdl-paragraph">${%customSymbols.description.1}</p>
     <s:code code="{plugin-root}/src/main/resources/images/symbols" />
 

--- a/src/main/resources/io/jenkins/plugins/designlibrary/TextBox/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/TextBox/index.jelly
@@ -33,7 +33,7 @@
       <code class="sample-remote language-xml" data-sample="example.jelly" />
     </pre>
 
-    <h2>${%autoCompletion}</h2>
+    <h2 id="auto-completion" class="jdl-heading">${%autoCompletion}</h2>
     <p class="jenkins-description">${%autoCompletion.description.1}</p>
     <div class="app-component-sample">
       <f:entry title="U.S. State" field="state">
@@ -87,7 +87,7 @@
     </pre>
 
 
-    <h2>${%syntaxHighlight}</h2>
+    <h2 id="syntax-highlighting" class="jdl-heading">${%syntaxHighlight}</h2>
 
     <p class="jenkins-description">${%syntaxHighlight.description.1}</p>
 

--- a/src/main/resources/io/jenkins/plugins/designlibrary/ToggleSwitch/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/ToggleSwitch/index.jelly
@@ -16,7 +16,7 @@
       <code class="sample-remote language-xml" data-sample="inverted.jelly"/>
     </pre>
 
-    <h2>${%dynamicLabels}</h2>
+    <h2 id="dynamic-labels" class="jdl-heading">${%dynamicLabels}</h2>
     <p class="jenkins-description">${%dynamicLabels.usage.1}</p>
     <p class="jenkins-description">${%dynamicLabels.usage.2}</p>
 

--- a/src/main/resources/io/jenkins/plugins/designlibrary/sample.js
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/sample.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll('.sample-remote')
     .forEach(element => {
       const fileName = element.dataset.sample;
-      const componentName = window.location.href.match(/.+design-library\/(.+)$/)[1]
+      const componentName = window.location.href.match(/.+design-library\/(.[^#]+)?/)[1]
 
       const fullUrl = `${url}/plugin/design-library/${componentName}${fileName}`;
       fetch(fullUrl)

--- a/src/main/resources/io/jenkins/plugins/designlibrary/search.js
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/search.js
@@ -1,20 +1,20 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const rootUrl = document.querySelector('head').dataset.rooturl
+  const data = document.querySelector("#search-data").textContent
   const searchWrapper = document.querySelector("#search-wrapper")
   const searchBar = document.querySelector("#search-bar")
   const searchResultsContainer = document.querySelector("#search-results-container")
   const searchBarResults = document.querySelector("#search-results")
 
   searchBar.addEventListener("input", () => {
-    const fullUrl = `${rootUrl}/design-library/search?query=${searchBar.value}`;
+    const query = searchBar.value.toLowerCase()
 
-    if (searchBar.value.length === 0) {
-      hideResultsContainer();
-      searchResultsContainer.style.height = "0px"
-      return;
+    // Hide the suggestions if the search query is empty
+    if (query.length === 0) {
+      hideResultsContainer()
+      return
     }
 
-    showResultsContainer();
+    showResultsContainer()
 
     function appendResults(container, results) {
       results.forEach(item => {
@@ -29,42 +29,46 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     }
 
-    fetch(fullUrl)
-      .then(response => response.json())
-      .then(json => {
-        searchBarResults.innerHTML = "";
+    // Filter results
+    const results = JSON.parse(data)
+      .filter(item => item.title.toLowerCase().includes(query) ||
+        item.children.some(child => child.title.toLowerCase().includes(query)))
+      .map(item => {
+        item.children = item.children.filter(child => child.title.toLowerCase().includes(query))
+        return item;
+      })
+      .slice(0, 5)
 
-        appendResults(searchBarResults, json["data"])
-
-        searchResultsContainer.style.height = searchBarResults.offsetHeight + "px"
-      });
-    })
+    searchBarResults.innerHTML = ""
+    appendResults(searchBarResults, results)
+    searchResultsContainer.style.height = searchBarResults.offsetHeight + "px"
+  })
 
   function createElementFromHtml(html) {
-    const template = document.createElement("template");
-    template.innerHTML = html.trim();
-    return template.content.firstElementChild;
+    const template = document.createElement("template")
+    template.innerHTML = html.trim()
+    return template.content.firstElementChild
   }
 
   function showResultsContainer() {
-    searchResultsContainer.classList.add("jdl-search-results-container--visible");
+    searchResultsContainer.classList.add("jdl-search-results-container--visible")
     document.querySelectorAll(".task").forEach(task => {
-      task.style.opacity = 0.25;
+      task.style.opacity = 0.25
     })
   }
 
   function hideResultsContainer() {
-    searchResultsContainer.classList.remove("jdl-search-results-container--visible");
+    searchResultsContainer.classList.remove("jdl-search-results-container--visible")
     searchResultsContainer.style.height = "0px"
     document.querySelectorAll(".task").forEach(task => {
-      task.style.opacity = 1;
+      task.style.opacity = 1
     })
   }
 
   searchBar.addEventListener("focusin", () => {
     if (searchBar.value.length !== 0) {
       searchResultsContainer.style.height = searchBarResults.offsetHeight + "px"
-      showResultsContainer();
+      showResultsContainer()
     }
   })
 
@@ -73,6 +77,6 @@ document.addEventListener("DOMContentLoaded", () => {
       return
     }
 
-    hideResultsContainer();
+    hideResultsContainer()
   })
-});
+})

--- a/src/main/resources/io/jenkins/plugins/designlibrary/search.js
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/search.js
@@ -1,10 +1,20 @@
 document.addEventListener("DOMContentLoaded", () => {
   const rootUrl = document.querySelector('head').dataset.rooturl
+  const searchWrapper = document.querySelector("#search-wrapper")
   const searchBar = document.querySelector("#search-bar")
+  const searchResultsContainer = document.querySelector("#search-results-container")
   const searchBarResults = document.querySelector("#search-results")
 
   searchBar.addEventListener("input", () => {
     const fullUrl = `${rootUrl}/design-library/search?query=${searchBar.value}`;
+
+    if (searchBar.value.length === 0) {
+      hideResultsContainer();
+      searchResultsContainer.style.height = "0px"
+      return;
+    }
+
+    showResultsContainer();
 
     function appendResults(container, results) {
       results.forEach(item => {
@@ -13,6 +23,10 @@ document.addEventListener("DOMContentLoaded", () => {
         appendResults(children, item["children"])
         container.append(children)
       })
+
+      if (results.length === 0 && container === searchBarResults) {
+        container.append(createElementFromHtml(`<p class="jdl-search-results__no-results-label">No results</p>`))
+      }
     }
 
     fetch(fullUrl)
@@ -22,13 +36,43 @@ document.addEventListener("DOMContentLoaded", () => {
 
         appendResults(searchBarResults, json["data"])
 
-        console.log(json)
+        searchResultsContainer.style.height = searchBarResults.offsetHeight + "px"
       });
     })
-});
 
-function createElementFromHtml(html) {
-  const template = document.createElement("template");
-  template.innerHTML = html.trim();
-  return template.content.firstElementChild;
-}
+  function createElementFromHtml(html) {
+    const template = document.createElement("template");
+    template.innerHTML = html.trim();
+    return template.content.firstElementChild;
+  }
+
+  function showResultsContainer() {
+    searchResultsContainer.classList.add("jdl-search-results-container--visible");
+    document.querySelectorAll(".task").forEach(task => {
+      task.style.opacity = 0.25;
+    })
+  }
+
+  function hideResultsContainer() {
+    searchResultsContainer.classList.remove("jdl-search-results-container--visible");
+    searchResultsContainer.style.height = "0px"
+    document.querySelectorAll(".task").forEach(task => {
+      task.style.opacity = 1;
+    })
+  }
+
+  searchBar.addEventListener("focusin", () => {
+    if (searchBar.value.length !== 0) {
+      searchResultsContainer.style.height = searchBarResults.offsetHeight + "px"
+      showResultsContainer();
+    }
+  })
+
+  document.addEventListener("click", event => {
+    if (searchWrapper.contains(event.target)) {
+      return
+    }
+
+    hideResultsContainer();
+  })
+});

--- a/src/main/resources/io/jenkins/plugins/designlibrary/search.js
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/search.js
@@ -1,0 +1,35 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const rootUrl = document.querySelector('head').dataset.rooturl
+  const searchBar = document.querySelector("#search-bar")
+  const searchBarResults = document.querySelector("#search-results")
+
+  searchBar.addEventListener("input", () => {
+    const fullUrl = `${rootUrl}/design-library/search?query=${searchBar.value}`;
+
+    searchBarResults.innerHTML = "";
+
+    function appendResults(container, results) {
+      results.forEach(item => {
+        container.append(createElementFromHtml(`<a href="${item.url}">${item.icon} ${item.title}</a>`))
+        const children = createElementFromHtml(`<div></div>`)
+        appendResults(children, item["children"])
+        container.append(children)
+      })
+    }
+
+    fetch(fullUrl)
+      .then(response => response.json())
+      .then(json => {
+
+        appendResults(searchBarResults, json["data"])
+
+        console.log(json)
+      });
+    })
+});
+
+function createElementFromHtml(html) {
+  const template = document.createElement("template");
+  template.innerHTML = html.trim();
+  return template.content.firstElementChild;
+}

--- a/src/main/resources/io/jenkins/plugins/designlibrary/search.js
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/search.js
@@ -6,8 +6,6 @@ document.addEventListener("DOMContentLoaded", () => {
   searchBar.addEventListener("input", () => {
     const fullUrl = `${rootUrl}/design-library/search?query=${searchBar.value}`;
 
-    searchBarResults.innerHTML = "";
-
     function appendResults(container, results) {
       results.forEach(item => {
         container.append(createElementFromHtml(`<a href="${item.url}">${item.icon} ${item.title}</a>`))
@@ -20,6 +18,7 @@ document.addEventListener("DOMContentLoaded", () => {
     fetch(fullUrl)
       .then(response => response.json())
       .then(json => {
+        searchBarResults.innerHTML = "";
 
         appendResults(searchBarResults, json["data"])
 

--- a/src/main/resources/lib/samples/sample.jelly
+++ b/src/main/resources/lib/samples/sample.jelly
@@ -42,6 +42,7 @@ THE SOFTWARE.
 
   <l:layout title="${title}">
     <st:adjunct includes="io.jenkins.plugins.designlibrary.styles" />
+    <st:adjunct includes="io.jenkins.plugins.designlibrary.search" />
     <st:adjunct includes="io.jenkins.plugins.designlibrary.sample" />
     <st:adjunct includes="io.jenkins.plugins.designlibrary.preCode" />
     <st:adjunct includes="io.jenkins.plugins.designlibrary.prism" />

--- a/src/main/resources/lib/samples/sidepanel.jelly
+++ b/src/main/resources/lib/samples/sidepanel.jelly
@@ -2,12 +2,16 @@
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:tasks>
     <div id="search-wrapper">
+      <div id="search-data" class="jenkins-hidden">
+        <j:if test="${disableSearch != true}">
+          ${it.search}
+        </j:if>
+      </div>
       <div class="jdl-search">
         <input
           class="jenkins-search__input jdl-search__input"
           type="search"
           id="search-bar"
-          value="${request.getParameter('search')}"
           placeholder="Search Design Library" />
         <div class="jdl-search__icon">
           <l:icon src="symbol-search"/>

--- a/src/main/resources/lib/samples/sidepanel.jelly
+++ b/src/main/resources/lib/samples/sidepanel.jelly
@@ -4,7 +4,7 @@
     <div id="search-wrapper">
       <div class="jdl-search">
         <input
-          class="jdl-search__input"
+          class="jenkins-search__input jdl-search__input"
           type="search"
           id="search-bar"
           value="${request.getParameter('search')}"
@@ -14,7 +14,9 @@
         </div>
       </div>
       <div style="position: relative">
-        <div id="search-results" />
+        <div class="jdl-search-results-container" id="search-results-container">
+          <div class="jdl-search-results" id="search-results" />
+        </div>
       </div>
     </div>
 

--- a/src/main/resources/lib/samples/sidepanel.jelly
+++ b/src/main/resources/lib/samples/sidepanel.jelly
@@ -1,6 +1,23 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:tasks>
+    <div id="search-wrapper">
+      <div class="jdl-search">
+        <input
+          class="jdl-search__input"
+          type="search"
+          id="search-bar"
+          value="${request.getParameter('search')}"
+          placeholder="Search Design Library" />
+        <div class="jdl-search__icon">
+          <l:icon src="symbol-search"/>
+        </div>
+      </div>
+      <div style="position: relative">
+        <div id="search-results" />
+      </div>
+    </div>
+
     <l:task title="${%Home}" href="${rootURL}/design-library" icon="symbol-home plugin-design-library" />
 
     <j:forEach var="s" items="${it.all}">

--- a/src/main/resources/scss/abstracts/_overrides.scss
+++ b/src/main/resources/scss/abstracts/_overrides.scss
@@ -2,6 +2,10 @@
   --jdl-spacing: 2rem;
 }
 
+:target {
+  scroll-margin-top: calc(40px + var(--jdl-spacing));
+}
+
 #main-panel {
   display: flex !important;
   flex-direction: column;

--- a/src/main/resources/scss/components/_index.scss
+++ b/src/main/resources/scss/components/_index.scss
@@ -1,4 +1,5 @@
 @use "component-sample";
 @use "dos-donts";
 @use "previous-next-controls";
+@use "search";
 @use "source-block";

--- a/src/main/resources/scss/components/_search.scss
+++ b/src/main/resources/scss/components/_search.scss
@@ -1,0 +1,167 @@
+@use "sass:math";
+
+#search-wrapper {
+  margin-left: -0.8rem;
+
+  .jdl-search {
+    position: relative;
+    height: 40px;
+    background: var(--item-background--hover);
+    border-radius: 10px;
+    margin-bottom: 1.2rem;
+
+    &__input {
+      position: absolute;
+      inset: 0;
+      background: none;
+      border: none;
+      outline: none;
+      padding-left: 1.1rem + 0.8rem + 0.8rem;
+      font-weight: 500;
+      line-height: 1;
+    }
+
+    &__icon {
+      position: absolute;
+      top: calc(50% - 0.525rem);
+      left: 0.8rem;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.1rem;
+      height: 1.1rem;
+
+      svg {
+        width: 1.1rem;
+        height: 1.1rem;
+      }
+    }
+
+  }
+}
+
+#search-results {
+  position: absolute;
+  top: 0.35rem;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border-radius: 10px;
+  padding: 0.5rem;
+  box-shadow: 0 10px 30px rgba(black, 0.2),
+              0 2px 10px rgba(black, 0.05),
+              inset 0 -1px 2px rgba(white, 0.025);
+  background: hsla(240deg, 11%, 14%, 0.6);
+  //background: rgba(white, 0.9);
+  max-height: 50vh;
+  overflow: auto;
+  z-index: 10;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    z-index: -1;
+  }
+
+  a {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.5rem 0.7rem;
+    font-size: 0.9rem;
+    border-radius: 10px;
+    color: var(--text-color);
+    font-weight: 500;
+    text-decoration: none;
+    z-index: 0;
+    line-height: 1;
+    min-height: 2.25rem;
+
+    svg {
+      width: 1.2rem;
+      height: 1.2rem;
+    }
+
+    &::before,
+    &::after {
+      position: absolute;
+      content: "";
+      inset: 0;
+      z-index: -1;
+      border-radius: 10px;
+      transition: var(--standard-transition);
+      pointer-events: none;
+    }
+
+    &::before {
+      background-color: transparent;
+    }
+
+    &::after {
+      box-shadow: 0 0 0 0.66rem transparent;
+    }
+
+    &:hover,
+    &:focus {
+      &::before {
+        background-color: var(--item-background--hover);
+      }
+    }
+
+    &:active,
+    &:focus {
+      outline: none !important;
+      z-index: 1;
+
+      &::before {
+        background-color: var(--item-background--active);
+      }
+
+      &::after {
+        box-shadow: 0 0 0 0.33rem var(--item-box-shadow--focus);
+      }
+    }
+
+    &:focus-visible {
+      &::after {
+        box-shadow: 0 0 0 0.33rem var(--text-color);
+      }
+    }
+  }
+
+  div {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: -0.25rem;
+
+    a {
+      padding-left: 2.6rem;
+      color: var(--text-color-secondary);
+    }
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0.4rem;
+      left: (1.1rem + math.div(0.125rem, 2));
+      bottom: 0.3rem;
+      width: 0.125rem;
+      background: currentColor;
+      border-radius: 100vmax;
+      opacity: 0.05;
+    }
+  }
+
+  &:empty {
+    display: none;
+  }
+}

--- a/src/main/resources/scss/components/_search.scss
+++ b/src/main/resources/scss/components/_search.scss
@@ -9,6 +9,8 @@
     background: var(--item-background--hover);
     border-radius: 10px;
     margin-bottom: 1.2rem;
+    box-shadow: 0 0 0 10px transparent;
+    transition: var(--standard-transition);
 
     &__input {
       position: absolute;
@@ -17,8 +19,10 @@
       border: none;
       outline: none;
       padding-left: 1.1rem + 0.8rem + 0.8rem;
+      padding-right: 0.5rem;
       font-weight: 500;
       line-height: 1;
+      box-shadow: none;
     }
 
     &__icon {
@@ -31,6 +35,7 @@
       justify-content: center;
       width: 1.1rem;
       height: 1.1rem;
+      pointer-events: none;
 
       svg {
         width: 1.1rem;
@@ -38,35 +43,42 @@
       }
     }
 
+    &:hover {
+      background: var(--item-background--active);
+    }
+
+    &:focus-within {
+      background: var(--item-background--active);
+      box-shadow: 0 0 0 5px var(--item-box-shadow--focus);
+    }
   }
 }
 
-#search-results {
+.jdl-search-results-container {
   position: absolute;
-  top: 0.35rem;
+  top: -0.5rem;
   left: 0;
   right: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  justify-content: flex-start;
   border-radius: 10px;
-  padding: 0.5rem;
   box-shadow: 0 10px 30px rgba(black, 0.2),
               0 2px 10px rgba(black, 0.05),
               inset 0 -1px 2px rgba(white, 0.025);
-  background: hsla(240deg, 11%, 14%, 0.6);
+  background: hsla(240deg, 11%, 14%, 0.8);
   //background: rgba(white, 0.9);
-  max-height: 50vh;
-  overflow: auto;
+  overflow: hidden;
   z-index: 10;
+  height: 0;
+  opacity: 0;
+  transition: var(--standard-transition);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-    z-index: -1;
+  &--visible {
+    opacity: 1;
+    top: 0;
   }
 
   a {
@@ -136,32 +148,46 @@
     }
   }
 
-  div {
+  .jdl-search-results {
     position: relative;
     display: flex;
+    justify-content: flex-start;
     flex-direction: column;
     gap: 0.25rem;
-    margin-top: -0.25rem;
+    padding: 0.5rem;
 
-    a {
-      padding-left: 2.6rem;
-      color: var(--text-color-secondary);
-    }
+    div {
+      position: relative;
+      margin-top: -0.25rem;
 
-    &::before {
-      content: "";
-      position: absolute;
-      top: 0.4rem;
-      left: (1.1rem + math.div(0.125rem, 2));
-      bottom: 0.3rem;
-      width: 0.125rem;
-      background: currentColor;
-      border-radius: 100vmax;
-      opacity: 0.05;
+      a {
+        padding-left: 2.6rem;
+        color: var(--text-color-secondary);
+      }
+
+      &::before {
+        content: "";
+        position: absolute;
+        top: 0.4rem;
+        left: (1.1rem + math.div(0.125rem, 2));
+        bottom: 0.3rem;
+        width: 0.125rem;
+        background: currentColor;
+        border-radius: 100vmax;
+        opacity: 0.05;
+      }
+
+      &:empty {
+        display: none;
+      }
     }
   }
+}
 
-  &:empty {
-    display: none;
-  }
+.jdl-search-results__no-results-label {
+  text-align: center;
+  margin: 2rem;
+  padding: 0;
+  color: var(--text-color-secondary);
+  font-weight: 500;
 }

--- a/src/main/resources/scss/components/_search.scss
+++ b/src/main/resources/scss/components/_search.scss
@@ -56,7 +56,7 @@
 
 .jdl-search-results-container {
   position: absolute;
-  top: -0.5rem;
+  top: 0;
   left: 0;
   right: 0;
   display: flex;
@@ -66,8 +66,8 @@
   box-shadow: 0 10px 30px rgba(black, 0.2),
               0 2px 10px rgba(black, 0.05),
               inset 0 -1px 2px rgba(white, 0.025);
-  background: hsla(240deg, 11%, 14%, 0.8);
-  //background: rgba(white, 0.9);
+  //background: hsla(240deg, 11%, 14%, 0.8);
+  background: rgba(white, 0.9);
   overflow: hidden;
   z-index: 10;
   height: 0;
@@ -75,10 +75,13 @@
   transition: var(--standard-transition);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
+  visibility: collapse;
+  transform: scale(0.95);
 
   &--visible {
     opacity: 1;
-    top: 0;
+    transform: scale(1);
+    visibility: visible;
   }
 
   a {

--- a/src/main/resources/scss/components/_search.scss
+++ b/src/main/resources/scss/components/_search.scss
@@ -90,7 +90,7 @@
     align-items: center;
     gap: 0.7rem;
     padding: 0.5rem 0.7rem;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     border-radius: 10px;
     color: var(--text-color);
     font-weight: 500;


### PR DESCRIPTION
Currently a draft PR as it's still a little rough around the edges, and there's some implementation questions too.

https://user-images.githubusercontent.com/43062514/177196132-a7dcd53b-f919-40ee-b8e3-d8b7e68a5b5c.mov

The idea behind the PR is to add a search function which enables users to search not only for pages, but also for a page's contents. This should improve discoverability of components for Jenkins/plugin developers.

The current implementation works by scanning all jelly files (in a similar fashion to how the dropdown menu items work) on first page load and caching their headings. This is currently done through Regex as for the life of me I couldn't get the XML parsing to work properly. This process is quite slow and is less than ideal.

The cached data is then stored (hidden) on the page as JSON, which is then picked up by the search bar component and rendered.

If anybody has a better implementation idea I'm all ears.

**What's a bit broken?**
* Doesn't look perfect on all themes
* Loading can be slow/a bit broken
* Anchors are some time in the wrong position due to JS loading after the page loads and shifting content

---

Once we have an agreed/merged solution it would be good to move the search bar component into Jenkins core so it can be reusable, there's a fair few different instances of the search bar and it'd be good to standardise it.

---

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
