### PR TITLE
Update library to use new button classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/design-library-plugin</gitHubRepo>
-        <jenkins.version>2.350</jenkins.version>
+        <jenkins.version>2.365</jenkins.version>
         <node.version>16.17.0</node.version>
         <npm.version>8.18.0</npm.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/design-library-plugin</gitHubRepo>
-        <jenkins.version>2.365</jenkins.version>
+        <jenkins.version>2.364</jenkins.version>
         <node.version>16.17.0</node.version>
         <npm.version>8.18.0</npm.version>
     </properties>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.jelly
@@ -25,80 +25,69 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="/lib/samples" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
   <s:sample>
-    <p class="jenkins-description">${%description.1}</p>
+    <p class="jdl-paragraph">${%description.1}</p>
 
-    <p class="jenkins-description">${%description.2}</p>
+    <p class="jdl-paragraph">${%description.2}</p>
 
-    <!-- TODO No idea when you would use a transparent button -->
-
-    <div class="app-component-sample">
+    <div class="jdl-component-sample">
       <button class="jenkins-button">Default</button>
     </div>
-    <pre>
-      <code class="language-html">
-        <button class="jenkins-button">Default</button>
-      </code>
-    </pre>
+    <s:code language="xml" file="default.jelly" />
 
-    <div class="app-component-sample">
+    <div class="jdl-component-sample">
       <button class="jenkins-button jenkins-button--primary">Primary</button>
     </div>
-    <pre>
-      <code class="language-html">
-        <button class="jenkins-button jenkins-button--primary">Primary</button>
-      </code>
-    </pre>
+    <s:code language="xml" file="primary.jelly" />
 
-    <div class="app-component-sample">
-      <button class="jenkins-button jenkins-button--destructive">Destructive</button>
+    <p class="jdl-paragraph">
+      You can pair buttons with <a href="../Colors">color modifier classes</a>, like so:
+    </p>
+
+    <div class="jdl-component-sample">
+      <button class="jenkins-button jenkins-!-destructive-color">Destructive</button>
     </div>
-    <pre>
-      <code class="language-html">
-        <button class="jenkins-button jenkins-button--destructive">Destructive</button>
-      </code>
-    </pre>
+    <s:code language="xml" file="destructive.jelly" />
 
-    <div class="app-component-sample">
-      <button class="jenkins-button jenkins-button--transparent">Transparent</button>
+    <p class="jdl-paragraph">
+      Tertiary buttons should be used for buttons which have minimal interaction or for those where
+      a background creates too much visual clutter:
+    </p>
+
+    <div class="jdl-component-sample">
+      <button class="jenkins-button jenkins-button--tertiary">Tertiary</button>
     </div>
-    <pre>
-      <code class="language-html">
-        <button class="jenkins-button jenkins-button--transparent">Transparent</button>
-      </code>
-    </pre>
+    <s:code language="xml" file="tertiary.jelly" />
 
-    <div class="app-component-sample">
+    <p class="jdl-paragraph">
+      Buttons can include symbols and they'll be automatically sized to fit correctly:
+    </p>
+
+    <div class="jdl-component-sample">
       <button class="jenkins-button"><l:icon src="symbol-add-outline plugin-ionicons-api" /> ${%symbol}</button>
     </div>
-    <pre>
-      <code class="sample-remote language-html" data-sample="symbolButton.jelly"/>
-    </pre>
+    <s:code language="xml" file="symbolButton.jelly" />
 
-    <h2>${%copy}</h2>
-    <p>${%copy.description}</p>
-    <div class="app-component-sample">
-      <l:copyButton message="text copied" text="Here comes the night time" tooltip="Click to copy" />
+    <h2 class="jdl-heading">${%copy}</h2>
+    <p class="jdl-paragraph">${%copy.description}</p>
+    <div class="jdl-component-sample">
+      <l:copyButton message="text copied" text="A shoulder of lemon fields" tooltip="Click to copy" />
     </div>
-    <pre>
-      <code class="sample-remote language-xml" data-sample="copyButton.jelly" />
-    </pre>
+    <s:code language="xml" file="copyButton.jelly" />
 
-    <p>${%copy.parameters}</p>
-    <ul>
+    <p class="jdl-paragraph">${%copy.parameters}</p>
+    <ul class="jdl-list">
       <li>text - ${%copy.parameters.text}</li>
       <li>message - ${%copy.parameters.message}</li>
     </ul>
 
-    <h2>${%help}</h2>
-    <div class="app-component-sample">
+    <h2 class="jdl-heading">${%help}</h2>
+    <div class="jdl-component-sample">
       <t:help href="https://www.jenkins.io" tooltip="${%Additional information on buttons}" />
     </div>
-    <pre>
-      <code class="sample-remote language-xml" data-sample="helpButton.jelly" />
-    </pre>
+    <s:code language="xml" file="helpButton.jelly" />
 
-    <p>${%help.parameters}</p>
-    <ul>
+    <p class="jdl-paragraph">${%help.parameters}</p>
+    <ul class="jdl-list">
       <li>href - ${%help.parameters.1}</li>
     </ul>
   </s:sample>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:s="/lib/"samples" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:s="/lib/samples" xmlns:l="/lib/layout">
   <s:sample>
     <j:set var="icons" value="${it.symbols}" />
     <div class="jdl-symbols__masthead">

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Symbols/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:s="/lib/samples" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:s="/lib/"samples" xmlns:l="/lib/layout">
   <s:sample>
     <j:set var="icons" value="${it.symbols}" />
     <div class="jdl-symbols__masthead">

--- a/src/main/resources/io/jenkins/plugins/designlibrary/sample.js
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/sample.js
@@ -38,26 +38,26 @@ document.addEventListener("DOMContentLoaded", () => {
         element.innerHTML = Prism.highlight(element.innerHTML, Prism.languages[language], language.pop())
       }
     });
-});
 
-const shareButton = document.querySelector("#button-share");
+  const shareButton = document.querySelector("#button-share");
 
-if (shareButton) {
-  if (!navigator.canShare) {
-    shareButton.style.display = "none"
-  }
+  if (shareButton) {
+    if (!navigator.canShare) {
+      shareButton.style.display = "none"
+    }
 
-  shareButton
-    .addEventListener("click", async (e) => {
-      try {
-        const shareData = {
-          title: document.title,
-          text: `Learn about ${document.querySelector("h1").textContent} on Jenkins Design Library`,
-          url: document.location.href
+    shareButton
+      .addEventListener("click", async (e) => {
+        try {
+          const shareData = {
+            title: document.title,
+            text: `Learn about ${document.querySelector("h1").textContent} on Jenkins Design Library`,
+            url: document.location.href
+          }
+          await navigator.share(shareData)
+        } catch (error) {
+          console.log(error)
         }
-        await navigator.share(shareData)
-      } catch (error) {
-        console.log(error)
-      }
-    });
-}
+      });
+  }
+});

--- a/src/main/resources/lib/samples/sample.jelly
+++ b/src/main/resources/lib/samples/sample.jelly
@@ -63,14 +63,14 @@ THE SOFTWARE.
 
       <div class="jdl-previous-next-controls">
         <j:if test="${it.previousPage != null}">
-          <a href="${rootURL}/design-library/${it.previousPage.urlName}" class="jenkins-button jenkins-button--transparent jdl-previous-button">
+          <a href="${rootURL}/design-library/${it.previousPage.urlName}" class="jenkins-button jenkins-button--tertiary jdl-previous-button">
             <l:icon src="symbol-arrow-back-outline plugin-ionicons-api" />
             <span>${%previous}</span>
             <span>${it.previousPage.displayName}</span>
           </a>
         </j:if>
         <j:if test="${it.nextPage != null}">
-          <a href="${rootURL}/design-library/${it.nextPage.urlName}" class="jenkins-button jenkins-button--transparent jdl-next-button">
+          <a href="${rootURL}/design-library/${it.nextPage.urlName}" class="jenkins-button jenkins-button--tertiary jdl-next-button">
             <span>${%next}</span>
             <l:icon src="symbol-arrow-forward-outline plugin-ionicons-api" />
             <span>${it.nextPage.displayName}</span>

--- a/src/main/resources/scss/components/_previous-next-controls.scss
+++ b/src/main/resources/scss/components/_previous-next-controls.scss
@@ -20,8 +20,8 @@
   .jdl-next-button {
     display: grid;
     grid-template-columns: auto auto;
-    font-size: 0.9rem;
     gap: 0.5rem 0.75rem;
+    font-size: 1.1rem;
 
     span {
       margin: 0;

--- a/src/main/webapp/Buttons/copyButton.jelly
+++ b/src/main/webapp/Buttons/copyButton.jelly
@@ -1,1 +1,1 @@
-<l:copyButton message="text copied" text="Here comes the night time" tooltip="Click to copy" />
+<l:copyButton message="text copied" text="A shoulder of lemon fields" tooltip="Click to copy" />

--- a/src/main/webapp/Buttons/default.jelly
+++ b/src/main/webapp/Buttons/default.jelly
@@ -1,0 +1,1 @@
+<button class="jenkins-button">Default</button>

--- a/src/main/webapp/Buttons/destructive.jelly
+++ b/src/main/webapp/Buttons/destructive.jelly
@@ -1,0 +1,1 @@
+<button class="jenkins-button jenkins-!-destructive-color">Destructive</button>

--- a/src/main/webapp/Buttons/primary.jelly
+++ b/src/main/webapp/Buttons/primary.jelly
@@ -1,0 +1,1 @@
+<button class="jenkins-button jenkins-button--primary">Primary</button>

--- a/src/main/webapp/Buttons/symbolButton.jelly
+++ b/src/main/webapp/Buttons/symbolButton.jelly
@@ -1,3 +1,3 @@
-<button class="jenkins-button jenkins-button--transparent">
+<button class="jenkins-button jenkins-button--tertiary">
   <l:icon src="symbol-add" /> With symbol
 </button>

--- a/src/main/webapp/Buttons/symbolButton.jelly
+++ b/src/main/webapp/Buttons/symbolButton.jelly
@@ -1,3 +1,3 @@
-<button class="jenkins-button jenkins-button--tertiary">
+<button class="jenkins-button">
   <l:icon src="symbol-add" /> With symbol
 </button>

--- a/src/main/webapp/Buttons/tertiary.jelly
+++ b/src/main/webapp/Buttons/tertiary.jelly
@@ -1,0 +1,1 @@
+<button class="jenkins-button jenkins-button--tertiary">Tertiary</button>


### PR DESCRIPTION
Buttons were updated in Jenkins [#6799](https://github.com/jenkinsci/jenkins/pull/6799) and some of the class names were changed. This PR updates the design library to use those new classes, as well as gives a small refresh to the buttons page.

There's still plenty of work needed to be done to the buttons page but it's an improvement over what we've got at the moment.

![new](https://user-images.githubusercontent.com/43062514/187317034-98442ff3-004a-4097-9e20-477b3c7ecd9c.png)

Also fixed the Share button not being clickable any more.

<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/121"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

