### PR TITLE
Adjust font size and weight + misc adjustments

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.properties
@@ -1,6 +1,6 @@
-description.1=Buttons are created with the <code>jenkins-button</code> CSS class. \
+description.1=Buttons are created with the <code>.jenkins-button</code> CSS class. \
    There are a number of different styles that can be added by adding another class alongside, \
-   such as <code>jenkins-button--primary</code>. Styling links as buttons is also supported.
+   such as <code>.jenkins-button--primary</code>. Styling links as buttons is also supported.
 description.2=Each form should have only one primary button. Most other buttons should just be the default one. \
    Destructive buttons should be used when something will be deleted or not easily undone. Generally these should have a confirmation page.
 symbol=With symbol

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.jelly
@@ -40,11 +40,11 @@ THE SOFTWARE.
             </j:if>
             <div class="jdl-colors__item__contents__line">
               <span>var(--${item.className ?: item.variable})</span>
-              <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="var(--${item.className ?: item.variable})"/>
+              <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="var(--${item.className ?: item.variable})" iconOnly="true" />
             </div>
             <div class="jdl-colors__item__contents__line">
               <span>.jenkins-!-${item.variable}</span>
-              <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="jenkins-!-${item.variable}"/>
+              <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="jenkins-!-${item.variable}" iconOnly="true" />
             </div>
           </div>
         </div>

--- a/src/main/resources/scss/abstracts/_mixins.scss
+++ b/src/main/resources/scss/abstracts/_mixins.scss
@@ -1,0 +1,7 @@
+@mixin base-text {
+  font-size: 1.05rem;
+  font-weight: 400;
+  line-height: 1.66;
+  -webkit-font-smoothing: subpixel-antialiased;
+  //color: red;
+}

--- a/src/main/resources/scss/abstracts/_mixins.scss
+++ b/src/main/resources/scss/abstracts/_mixins.scss
@@ -3,5 +3,4 @@
   font-weight: 400;
   line-height: 1.66;
   -webkit-font-smoothing: subpixel-antialiased;
-  //color: red;
 }

--- a/src/main/resources/scss/abstracts/_overrides.scss
+++ b/src/main/resources/scss/abstracts/_overrides.scss
@@ -71,6 +71,7 @@ pre {
 
 code {
   font-family: var(--font-family-mono) !important;
+  color: var(--text-color-secondary);
 }
 
 hr {
@@ -81,4 +82,8 @@ hr {
   background: currentColor;
   margin: 0 0 var(--jdl-spacing) 0;
   opacity: 0.1;
+}
+
+a {
+  font-weight: inherit;
 }

--- a/src/main/resources/scss/abstracts/_typography.scss
+++ b/src/main/resources/scss/abstracts/_typography.scss
@@ -1,3 +1,5 @@
+@use "mixins";
+
 .jdl-heading {
   font-weight: 600;
   font-size: 1.2rem;
@@ -16,10 +18,8 @@
 }
 
 .jdl-paragraph {
-  font-size: 1.1rem;
-  font-weight: 500;
+  @include mixins.base-text;
   margin: 0 0 var(--jdl-spacing) 0;
-  line-height: 1.66;
 
   & + & {
     margin-top: calc((var(--jdl-spacing) / 2) * -1);
@@ -27,16 +27,16 @@
 }
 
 .jdl-list {
-  font-size: 1.1rem;
-  font-weight: 500;
+  @include mixins.base-text;
   margin: 0 0 var(--jdl-spacing) 0;
-  line-height: 1.66;
 }
 
 .jdl-important-point {
+  @include mixins.base-text;
   position: relative;
-  font-size: 1rem;
+  font-weight: 500;
   padding-left: calc(1.5rem + 1ch);
+  line-height: 1.5;
 
   &::before {
     content: "";

--- a/src/main/resources/scss/components/_previous-next-controls.scss
+++ b/src/main/resources/scss/components/_previous-next-controls.scss
@@ -1,3 +1,5 @@
+@use "../abstracts/mixins";
+
 .jdl-previous-next-controls {
   position: relative;
   display: flex;
@@ -18,10 +20,10 @@
 
   .jdl-previous-button,
   .jdl-next-button {
+    @include mixins.base-text;
     display: grid;
     grid-template-columns: auto auto;
     gap: 0.5rem 0.75rem;
-    font-size: 1.1rem;
 
     span {
       margin: 0;

--- a/src/main/resources/scss/pages/_colors.scss
+++ b/src/main/resources/scss/pages/_colors.scss
@@ -1,3 +1,5 @@
+@use "../abstracts/mixins";
+
 .jdl-colors-tag {
   background-image: -webkit-linear-gradient(45deg, var(--red, red), var(--orange, orange), var(--yellow, yellow), var(--green, green), var(--blue, blue), var(--violet, violet), var(--red, red));
   -webkit-background-clip: text;
@@ -68,28 +70,34 @@
         flex-direction: column;
         align-items: flex-start;
         justify-content: flex-start;
-        gap: 0.5rem;
+        gap: 0.5rem 0.25rem;
 
         .jdl-colors__item__contents__title {
-          font-size: 1rem;
-          font-weight: 600;
-          line-height: 1.5rem;
+          @include mixins.base-text;
+          font-weight: 500;
           margin: 0;
         }
 
         .jdl-colors__item__contents__description {
-          font-size: 0.95rem;
-          font-weight: 500;
+          @include mixins.base-text;
           color: var(--text-color-secondary);
           margin: 0 0 0.5rem 0;
         }
 
         .jdl-colors__item__contents__line {
+          display: flex;
+          align-items: center;
+          justify-content: start;
           font-family: var(--font-family-mono);
           font-size: 0.85rem;
           font-weight: 500;
           color: var(--text-color-secondary);
           opacity: 0.85;
+
+          .jenkins-button {
+            margin-block: -0.66rem;
+            margin-inline-start: 0.33rem;
+          }
         }
       }
     }

--- a/src/main/resources/scss/pages/_home.scss
+++ b/src/main/resources/scss/pages/_home.scss
@@ -1,3 +1,5 @@
+@use "../abstracts/mixins";
+
 .app-home {
   position: relative;
   display: flex;
@@ -184,16 +186,13 @@
 }
 
 .app-card__title {
+  @include mixins.base-text;
   margin: 0;
-  font-weight: 600;
-  font-size: 1.05rem;
-  padding-bottom: 5px;
+  font-weight: 500;
 }
 
 .app-card__description {
+  @include mixins.base-text;
   margin: 0;
   color: var(--text-color-secondary);
-  line-height: 1.5;
-  font-weight: 500;
-  font-size: 1.05rem;
 }


### PR DESCRIPTION
Font sizes and weights have been adjusted for `jdl-` classes, on average the font is a touch smaller and also is less heavy. Nothing drastic but makes the pages a little cleaner.

**Before**
<img width="915" alt="image" src="https://user-images.githubusercontent.com/43062514/188490151-f8d9eab6-5f91-4e3e-a8a5-681c4b89da88.png">

**After**
<img width="913" alt="image" src="https://user-images.githubusercontent.com/43062514/188490139-5be19f23-1236-479f-aa50-855bf6d2b65c.png">

---

**Before**
<img width="873" alt="image" src="https://user-images.githubusercontent.com/43062514/188490225-2c36d322-e6df-48ad-a0d2-9754404c4a6d.png">

**After**
<img width="887" alt="image" src="https://user-images.githubusercontent.com/43062514/188490113-88229a01-be83-4405-ad36-59bdaa4030da.png">


<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/130"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

