### PR TITLE
Consistent quotes in American English `.properties` files

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/Layouts/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Layouts/index.properties
@@ -5,8 +5,8 @@ two-column.do.1=Include a title on your sidebar that best encapsulates its child
 two-column.do.2=Ensure all child pages share the same sidebar for consistency
 two-column.do.3=Buttons should only relate to/manipulate their parent column
 two-column.do.4=One (and only one) sidebar item should be in its selected state at a time
-two-column.dont.1=Don''t include hierarchical navigation in your sidebar, such as 'Back to Dashboard' or 'Up'
+two-column.dont.1=Don''t include hierarchical navigation in your sidebar, such as "Back to Dashboard" or "Up"
 two-column.dont.2=Don''t include actions or external pages in your sidebar, these belong in the top app bar
 
-one-column.do.1=Use the 'one-column' layout if your page doesn''t need a sidebar
+one-column.do.1=Use the "one-column" layout if your page doesn''t need a sidebar
 one-column.dont.1=Avoid sprawling content, use tabs if your page is lengthy and can be separated into clearly labelled sections

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Links/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Links/index.properties
@@ -27,9 +27,9 @@ blurb.modelLink=<p class="jdl-paragraph">By adding CSS class "model-link" to the
 
 blurb.modelLink.inside=\
   <p class="jdl-paragraph">Unless the hyperlink appears inline, it is often better to pre-allocate a space for the context menu anchor \
-  that appears when the mouse hovers over. To do this, also add the 'inside' CSS element. For example:
+  that appears when the mouse hovers over. To do this, also add the "inside" CSS element. For example:
 
 
 blurb.tltr=<p class="jdl-paragraph">By default, context menu appears below the link ,but this is inconvenient when model links line up in a vertical list. \
-  Add additional "tl-tr" CSS class (read it as 'top-left of the context menu to top-right of the target anchor) to \
+  Add additional "tl-tr" CSS class (read it as "top-left of the context menu to top-right of the target anchor") to \
   make context menu appear on the right.

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Select/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Select/index.properties
@@ -4,4 +4,4 @@ config page for the <code>descriptor</code> by creating a file called <code>conf
 usage.2=If you want a simpler <code>select</code> to be rendered you can use the <code>f:select</code> \
 Jelly tag and create a <code>doFillFieldNameItems</code> method in the <code>descriptor</code>.
 dynamic=Dynamic select
-dynamic.description=Updates the contents of a 'select' control dynamically based on selections of other controls.
+dynamic.description=Updates the contents of a "select" control dynamically based on selections of other controls.

--- a/src/main/resources/io/jenkins/plugins/designlibrary/TextBox/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/TextBox/index.properties
@@ -1,7 +1,7 @@
 autoCompletion=Auto-completion
 autoCompletion.description.1=Start typing a US state for autocomplete results to appear.
 autoCompletion.description.2=Textboxes can feature auto-completion items by Stapler finds this method via the naming convention.
-combobox.description=There is a similar control to the autocomplete functionality of 'textbox' called combobox:
+combobox.description=There is a similar control to the autocomplete functionality of "textbox" called combobox:
 dynamicCombobox=Dynamic combobox
 dynamicCombobox.description=Like many other fields combo-boxes can be updated dynamically based on other field values:
 syntaxHighlight=Syntax-highlighted text

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Validation/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Validation/index.properties
@@ -1,7 +1,7 @@
 title=Form field validation can access values of the nearby input controls, \
   which is useful for performing complex context-sensitive form validation. \
   The same technique can be also used for auto-completion, populating combobox/listbox, and so on. \
-  The example below is a bit contrived, but all the input elements are named 'name' (for city name and state name), \
+  The example below is a bit contrived, but all the input elements are named "name" (for city name and state name), \
   and we use <code><a href="https://javadoc.jenkins.io/hudson/RelativePath.html">@RelativePath</a></code> \
   so that the validation of the state name refers to the capital name, and the validation of the city name refers to the state name.
 validation.description=To implement this you need to provide a <code>doCheckXXX</code> method, where XXX is the name of your field. \


### PR DESCRIPTION
Per [the Javadoc](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/MessageFormat.html):

> A single quote itself must be represented by doubled single quotes `''` throughout a _String_.

A number of single quotes in English `.properties` files were intended to be displayed as single quotes but were incorrectly encoded. Anyway, these English `.properties` are implicitly American English (en-US), and in American English (as opposed to British English) double quotes are used in this context rather than single quotes. So this should be displayed as double quotes. So I am changing these to double quotes. Note that if British users wish to see single quotes, they can create a British English (en-GB) localization with their preferred quoting convention.

To test this PR I confirmed that the quotes weren't showing up at all before this PR and showed up as double quotes after this PR.

<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/163"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

