### PR TITLE
Add search bar for top level items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/design-library-plugin</gitHubRepo>
-        <jenkins.version>2.375</jenkins.version>
+        <jenkins.version>2.383</jenkins.version>
         <node.version>18.12.1</node.version>
         <npm.version>9.2.0</npm.version>
     </properties>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/search.js
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/search.js
@@ -1,0 +1,12 @@
+const searchBarInput = document.querySelector("#design-library-search-bar");
+
+searchBarInput.suggestions = function () {
+  return [...document.querySelectorAll(".task-link")]
+    .map((item) => ({
+      url: item.href,
+      icon: item.querySelector(
+        ".task-icon-link"
+      ).innerHTML,
+      label: item.querySelector(".task-link-text").textContent,
+    }));
+};

--- a/src/main/resources/lib/samples/sidepanel.jelly
+++ b/src/main/resources/lib/samples/sidepanel.jelly
@@ -1,10 +1,14 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
   <l:tasks>
+    <l:search-bar placeholder="${%Search Design Library}" id="design-library-search-bar" autofocus="true"  />
+
     <l:task title="${%Home}" href="${rootURL}/design-library" icon="symbol-home-outline plugin-ionicons-api" />
 
     <j:forEach var="s" items="${it.all}">
       <l:task title="${s.displayName}" href="${rootURL}/design-library/${s.urlName}" icon="${s.iconFileName} plugin-design-library" />
     </j:forEach>
   </l:tasks>
+
+  <st:adjunct includes="io.jenkins.plugins.designlibrary.search" />
 </j:jelly>


### PR DESCRIPTION
<img width="662" alt="image" src="https://user-images.githubusercontent.com/43062514/208763675-316932bf-aa2a-4fab-a3bd-96a17cbe6595.png">

Adds a search bar to the Design Library so you can quickly switch between different categories with just your keyboard.

---

Requires https://github.com/jenkinsci/jenkins/pull/7314 to work. 

<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/188"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

