### PR TITLE
Enable automerge on renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "reviewers": [
     "team:sig-ux"
   ],
+  "automerge": true,
   "packageRules": [
     {
       "matchDatasources": ["npm"],


### PR DESCRIPTION
Less clicks, we can possibly decide later if we want it to get auto-approved as well

<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/242"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

