### PR TITLE
Fix type error on textbox page

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/TextBox/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/TextBox/index.jelly
@@ -50,11 +50,13 @@
 
     <p class="jdl-paragraph">${%combobox.description}</p>
 
-    <div class="app-component-sample">
-      <f:entry title="U.S. State" field="state">
-        <f:combobox />
-      </f:entry>
-    </div>
+    <form>
+      <div class="app-component-sample">
+        <f:entry title="U.S. State" field="state">
+          <f:combobox />
+        </f:entry>
+      </div>
+    </form>
 
     <code>config.jelly:</code>
     <pre>
@@ -69,12 +71,14 @@
     <h3>${%dynamicCombobox}</h3>
     <p class="jdl-paragraph">${%dynamicCombobox.description}</p>
 
-    <f:entry title="Beatles Album" field="album">
-      <f:select />
-    </f:entry>
-    <f:entry title="Title" field="title">
-      <f:combobox />
-    </f:entry>
+    <form>
+      <f:entry title="Beatles Album" field="album">
+        <f:select />
+      </f:entry>
+      <f:entry title="Title" field="title">
+        <f:combobox />
+      </f:entry>
+    </form>
 
     <code>config.jelly:</code>
     <pre>


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/design-library-plugin/issues/102

The combobox control requires to be wrapped in a form.

There's some very questionable JavaScript in core for it that could do with replacing but this component isn't widely used.

Noticed while testing https://github.com/jenkinsci/jenkins/pull/7781