### PR TITLE
Remove usage of `l:js`

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/Notifications/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Notifications/index.jelly
@@ -60,6 +60,6 @@
             code="notificationBar.hide()"
             executable="true" />
 
-    <script src="${resURL}/jsbundles/section-to-tabs.js" type="text/javascript" defer="true" />
+    <script src="${resURL}/jsbundles/section-to-tabs.js" type="text/javascript" />
   </s:sample>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Notifications/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Notifications/index.jelly
@@ -60,6 +60,6 @@
             code="notificationBar.hide()"
             executable="true" />
 
-    <l:js src="jsbundles/section-to-tabs.js" />
+    <script src="${resURL}/jsbundles/section-to-tabs.js" type="text/javascript" defer="true" />
   </s:sample>
 </j:jelly>


### PR DESCRIPTION
Does not require https://github.com/jenkinsci/jenkins/pull/7827, but needed before https://github.com/jenkinsci/jenkins/pull/7827 can be merged and released. To test this PR, I viewed the **Notifications** page of the design library with the changes from this PR and https://github.com/jenkinsci/jenkins/pull/7827 and verified I could successfully click from one tab to the next as before.

<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/249"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

