### PR TITLE
Interface refinements

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/Root/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Root/index.jelly
@@ -8,8 +8,6 @@
 
     <l:main-panel>
       <div class="app-home">
-        <p class="app-home__jenkins-title">Jenkins</p>
-        <h1 class="app-home__heading">${%title}</h1>
         <div class="app-card__container">
           <div class="app-card__preview">
             <div class="app-card__preview__introduction">

--- a/src/main/resources/lib/samples/sidepanel.jelly
+++ b/src/main/resources/lib/samples/sidepanel.jelly
@@ -1,7 +1,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
+  <div class="app-sidepanel__jenkins-logo">Jenkins</div>
+
+  <l:app-bar title="Design Library" />
+
   <l:tasks>
-    <l:search-bar placeholder="${%Search Design Library}" id="design-library-search-bar" autofocus="true"  />
+    <l:search-bar placeholder="${%Search Design Library}" id="design-library-search-bar" />
 
     <l:task title="${%Home}" href="${rootURL}/design-library" icon="symbol-home-outline plugin-ionicons-api" />
 

--- a/src/main/resources/scss/abstracts/_overrides.scss
+++ b/src/main/resources/scss/abstracts/_overrides.scss
@@ -7,6 +7,7 @@
   flex-direction: column;
   width: 100%;
   max-width: min(1200px, 65vw);
+  margin-top: 18px;
   margin-left: auto;
   margin-right: auto;
 
@@ -90,4 +91,20 @@ hr {
 
 a {
   font-weight: inherit;
+}
+
+#side-panel .jenkins-app-bar {
+  margin-top: 50px;
+  margin-bottom: -10px;
+}
+
+.app-sidepanel__jenkins-logo {
+  position: absolute;
+  top: 130px;
+  left: var(--section-padding);
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: "Georgia", serif;
+  color: var(--text-color-secondary);
+  margin: 0;
 }

--- a/src/main/resources/scss/pages/_home.scss
+++ b/src/main/resources/scss/pages/_home.scss
@@ -9,22 +9,6 @@
   gap: 2rem;
 }
 
-.app-home__jenkins-title {
-  font-size: 1.15rem;
-  font-weight: 600;
-  font-family: "Georgia", serif;
-  color: var(--text-color-secondary);
-  margin: 0;
-  background-color: var(--background);
-}
-
-.app-home__heading {
-  font-size: 2.5rem;
-  font-weight: 800;
-  margin: -2rem 0 0;
-  background-color: var(--background);
-}
-
 .app-home__subheading {
   margin: 0 0 -1.2rem;
   font-weight: 600;
@@ -72,7 +56,7 @@
   overflow: hidden;
   margin-bottom: 0.8rem;
   transition: var(--standard-transition);
-  border-radius: 10px;
+  border-radius: 1rem;
   z-index: 0;
 
   svg {
@@ -140,28 +124,39 @@
   background-position-x: calc(var(--sidebar-width) + ((100vw - (var(--content-width) + var(--sidebar-width))) / 2));
 }
 
-.app-card__preview::before {
-  background-image: radial-gradient(at 40% 20%, hsla(28, 100%, 74%, 1) 0, transparent 50%),
-  radial-gradient(at 80% 0%, hsla(189, 100%, 56%, 1) 0, transparent 50%),
-  radial-gradient(at 0% 50%, hsla(355, 85%, 93%, 1) 0, transparent 50%),
-  radial-gradient(at 80% 50%, hsl(359, 70%, 46%) 0, transparent 50%),
-  radial-gradient(at 0% 100%, hsla(22, 100%, 77%, 1) 0, transparent 50%),
-  radial-gradient(at 80% 100%, hsla(242, 100%, 70%, 1) 0, transparent 50%),
-  radial-gradient(at 0% 0%, hsla(343, 100%, 76%, 1) 0, transparent 50%);
-  animation: rotate-colors 10s linear infinite;
+.app-card__preview {
+  &::before {
+    background-image: radial-gradient(
+                    at 40% 20%,
+                    var(--orange) 0,
+                    transparent 50%
+    ),
+    radial-gradient(at 80% 0%, var(--cyan) 0, transparent 50%),
+    radial-gradient(at 0% 50%, var(--light-pink) 0, transparent 50%),
+    radial-gradient(at 80% 50%, var(--light-red) 0, transparent 50%),
+    radial-gradient(at 0% 100%, var(--light-yellow) 0, transparent 50%),
+    radial-gradient(at 80% 100%, var(--dark-purple) 0, transparent 50%),
+    radial-gradient(at 0% 0%, var(--pink) 0, transparent 50%);
+    animation: aurora-one 5s linear infinite;
+  }
+
+  &::after {
+    background-image: radial-gradient(
+                    at 40% 20%,
+                    var(--light-cyan) 0,
+                    transparent 50%
+    ),
+    radial-gradient(at 80% 0%, var(--dark-orange) 0, transparent 50%),
+    radial-gradient(at 0% 50%, var(--light-blue) 0, transparent 50%),
+    radial-gradient(at 80% 50%, var(--light-green) 0, transparent 50%),
+    radial-gradient(at 0% 100%, var(--light-red) 0, transparent 50%),
+    radial-gradient(at 80% 100%, var(--light-yellow) 0, transparent 50%),
+    radial-gradient(at 0% 0%, var(--cyan) 0, transparent 50%);
+    animation: aurora-two 8s linear infinite;
+  }
 }
 
-.app-card__preview::after {
-  background-image: radial-gradient(at 80% 0%, hsla(13, 100%, 56%, 1) 0, transparent 50%),
-  radial-gradient(at 0% 50%, hsl(31, 100%, 80%) 0, transparent 50%),
-  radial-gradient(at 80% 50%, hsla(164, 100%, 76%, 1) 0, transparent 50%),
-  radial-gradient(at 0% 100%, hsl(206, 60%, 57%) 0, transparent 50%),
-  radial-gradient(at 80% 100%, hsl(146, 64%, 79%) 0, transparent 50%),
-  radial-gradient(at 0% 0%, hsla(167, 100%, 76%, 1) 0, transparent 50%);
-  animation: rotate-colors-2 10s linear infinite;
-}
-
-@keyframes rotate-colors {
+@keyframes aurora-one {
   0% {
     opacity: 0.2;
   }
@@ -173,7 +168,7 @@
   }
 }
 
-@keyframes rotate-colors-2 {
+@keyframes aurora-two {
   0% {
     opacity: 0.55;
   }


### PR DESCRIPTION
* Moves the app bar to the side panel in accordance with https://weekly.ci.jenkins.io/design-library/Layouts/
* Uses colour variables instead of hardcoded colours
* Removes the autofocus (distracting, and annoying on mobile)
* Cards are more rounded (inline with the updated About page)

**Before**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/43062514/236843615-6a7efd25-2caf-4ea5-91f5-c6fbaa7af815.png">

**After**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/43062514/236843740-d5dece71-478a-44b9-8797-2102fc6604f3.png">


<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/258"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

