### PR TITLE
Fix Layouts page

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/Layouts/layout-preview.js
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Layouts/layout-preview.js
@@ -1,5 +1,5 @@
 window.addEventListener("load", () => {
-  const appBar = document.querySelector(".jenkins-app-bar")
+  const appBar = document.querySelector("#main-panel .jenkins-app-bar")
   const componentSample = document.querySelector(".jdl-component-sample")
   const tabBar = document.querySelector(".tabBar")
   const twoPaneTab = tabBar.querySelector(".tab:first-of-type")


### PR DESCRIPTION
Broken due to the introduction of the side panel app bar in #258. This PR fixes the bug by improving the specificity of the app bar selector.

**Before**
<img width="1386" alt="image" src="https://github.com/jenkinsci/design-library-plugin/assets/43062514/33f32a31-39de-4cc0-a7fb-d6c2e5984489">

**After**
<img width="927" alt="image" src="https://github.com/jenkinsci/design-library-plugin/assets/43062514/0344698e-5f4f-4b92-b5f0-50e2831c2f9b">


<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/269"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

