### PR TITLE
fix badge in twocolumn layout

### DIFF
--- a/src/main/java/io/jenkins/plugins/designlibrary/Layouts.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Layouts.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.designlibrary;
 
 import hudson.Extension;
+import jenkins.management.Badge;
 
 @Extension
 public class Layouts extends UISample {
@@ -12,6 +13,10 @@ public class Layouts extends UISample {
     @Override
     public String getIconFileName() {
         return "symbol-layouts";
+    }
+
+    public Badge getBadge() {
+        return new Badge("123", "A tooltip describing the badge", Badge.Severity.INFO);
     }
 
     @Extension

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Layouts/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Layouts/index.jelly
@@ -90,7 +90,7 @@
       <h3 class="jdl-heading">${%Badges}</h3>
 
       <p class="jdl-paragraph">
-        You can include badges in your sidebar to highlight important information.
+        You can include badges (instances of <a href="https://javadoc.jenkins.io/jenkins/management/Badge.html" target="_blank"><code>jenkins.management.badge</code></a>) in your sidebar to highlight important information.
         You should only use a badge if the information is useful to the user, for example:
       </p>
 

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Layouts/twoColumn.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Layouts/twoColumn.jelly
@@ -7,7 +7,7 @@
       <l:tasks>
         <l:task title="Root" href="./twoColumn" icon="symbol-jenkins" />
         <l:task title="Second page" href="./twoColumn" icon="symbol-edit" />
-        <l:task title="Third page" href="./twoColumn" icon="symbol-details" badge="123" />
+        <l:task title="Third page" href="./twoColumn" icon="symbol-details" badge="${it.badge}" />
       </l:tasks>
     </l:side-panel>
 

--- a/src/main/webapp/Layouts/twoColumn.jelly
+++ b/src/main/webapp/Layouts/twoColumn.jelly
@@ -5,7 +5,7 @@
     <l:tasks>
       <l:task title="Root" href="..." icon="symbol-jenkins" />
       <l:task title="Second page" href="..." icon="symbol-edit" />
-      <l:task title="Third page" href="..." icon="symbol-details" badge="123" />
+      <l:task title="Third page" href="..." icon="symbol-details" badge="${it.badge}" />
     </l:tasks>
   </l:side-panel>
 


### PR DESCRIPTION
pass an instance of Badge to task so it is properly rendered

<!-- Please describe your pull request here. -->

### Testing done
Before:
![image](https://github.com/jenkinsci/design-library-plugin/assets/17767050/e9e22b1a-fab1-4543-bc66-a5c9ac83ba36)
After:
![image](https://github.com/jenkinsci/design-library-plugin/assets/17767050/bb111b00-be81-4c8f-a5d8-a71069a70061)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->


<a href="https://gitpod.io/#https://github.com/jenkinsci/design-library-plugin/pull/278"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

