### PR TITLE
Display plugin version on home page

### DIFF
--- a/src/main/java/io/jenkins/plugins/designlibrary/Home.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Home.java
@@ -1,9 +1,11 @@
 package io.jenkins.plugins.designlibrary;
 
 import hudson.Extension;
+import hudson.PluginWrapper;
 import hudson.model.RootAction;
 import java.util.List;
 import java.util.Map;
+import jenkins.model.Jenkins;
 
 /**
  * Entry point to all the UI samples.
@@ -44,5 +46,16 @@ public class Home implements RootAction {
             }
         }
         return null;
+    }
+
+    public String getPluginVersion() {
+        Jenkins jenkins = Jenkins.get();
+        if (jenkins != null) {
+            PluginWrapper plugin = jenkins.getPluginManager().getPlugin("design-library");
+            if (plugin != null) {
+                return plugin.getVersion(); // Return the plugin version
+            }
+        }
+        return "Version not available"; // Fallback message if version is not found
     }
 }

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Home/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Home/index.jelly
@@ -59,7 +59,6 @@
                   href="https://github.com/jenkinsci/design-library-plugin" />
         </div>
       </s:section>
-
       <s:previous-next-controls previousPage="${null}" nextPage="${it.all.0}" />
     </l:main-panel>
   </l:layout>

--- a/src/main/resources/lib/samples/previous-next-controls.jelly
+++ b/src/main/resources/lib/samples/previous-next-controls.jelly
@@ -32,6 +32,16 @@
       </j:if>
     </div>
     <div>
+      <j:if test="${attrs.previousPage == null and isHome}">
+        <a href="https://github.com/jenkinsci/design-library-plugin/releases/tag/${it.pluginVersion}" 
+          target="_blank" 
+          class="jenkins-button jenkins-button--tertiary jdl-plugin-version-link">
+          <l:icon src="symbol-design-library plugin-design-library" />
+          <span>current version: ${it.pluginVersion}</span>
+        </a>
+      </j:if>
+    </div>
+    <div>
       <j:if test="${attrs.nextPage != null}">
         <a href="${rootURL}/design-library/${attrs.nextPage.urlName}" class="jenkins-button jenkins-button--tertiary jdl-next-button">
           <span>${attrs.nextPage.displayName}</span>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
A draft to add plugin version at the footer of home page. Facing errors so a draft pull request , otherwise it was displaying current version: ( without the exact version , maybe due to error )
### Testing done
Generating error:
[ERROR] Failures: 
[ERROR]   InjectedTest.testPluginActive design-library failed to start
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
