### PR TITLE
Add 'Build' primary button example

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.jelly
@@ -73,7 +73,10 @@ THE SOFTWARE.
       </s:group>
       <s:group>
         <s:preview>
-          <button class="jenkins-button jenkins-!-destructive-color">Destructive</button>
+          <button class="jenkins-button jenkins-!-destructive-color">
+            <l:icon src="symbol-trash" />
+            Delete
+          </button>
         </s:preview>
         <s:code file="destructive.jelly" />
       </s:group>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Buttons/index.jelly
@@ -43,18 +43,6 @@ THE SOFTWARE.
       </s:group>
     </s:section>
 
-    <s:section title="${%modifiers}" description="${%modifiers.description}">
-      <s:group>
-        <s:preview>
-          <button class="jenkins-button jenkins-!-destructive-color">Destructive</button>
-        </s:preview>
-        <s:code file="destructive.jelly" />
-      </s:group>
-      <p class="jdl-section__description">
-        ${%destructive.description}
-      </p>
-    </s:section>
-
     <s:section title="${%tertiary}" description="${%tertiary.description}">
       <s:group>
         <s:preview>
@@ -71,6 +59,27 @@ THE SOFTWARE.
         </s:preview>
         <s:code file="symbolButton.jelly" />
       </s:group>
+    </s:section>
+
+    <s:section title="${%modifiers}" description="${%modifiers.description}">
+      <s:group>
+        <s:preview>
+          <button class="jenkins-button jenkins-button--primary jenkins-!-build-color">
+            <l:icon src="symbol-play" />
+            Build
+          </button>
+        </s:preview>
+        <s:code file="build.jelly" />
+      </s:group>
+      <s:group>
+        <s:preview>
+          <button class="jenkins-button jenkins-!-destructive-color">Destructive</button>
+        </s:preview>
+        <s:code file="destructive.jelly" />
+      </s:group>
+      <p class="jdl-section__description">
+        ${%destructive.description}
+      </p>
     </s:section>
 
     <s:section title="${%copy}" description="${%copy.description}">

--- a/src/main/webapp/Buttons/build.jelly
+++ b/src/main/webapp/Buttons/build.jelly
@@ -1,0 +1,4 @@
+<button class="jenkins-button jenkins-button--primary jenkins-!-build-color">
+  <l:icon src="symbol-play" />
+  Build
+</button>

--- a/src/main/webapp/Buttons/destructive.jelly
+++ b/src/main/webapp/Buttons/destructive.jelly
@@ -1,1 +1,4 @@
-<button class="jenkins-button jenkins-!-destructive-color">Destructive</button>
+<button class="jenkins-button jenkins-!-destructive-color">
+  <l:icon src="symbol-trash" />
+  Delete
+</button>


### PR DESCRIPTION
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/48eb7a0f-f95d-4e08-9cee-05cb5846874e" />

* Adds an example for a primary button with a colour modifier. 
* Updated the destructive an example to actually show what a destructive button could look like. 
* Moved the section down, so that it's more of a culmination of the examples above it.