### PR TITLE
Update .gitpod.yml to use Java 21 by default

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,14 @@
 tasks:
-  - init: mvn install -P quick-build
+  - init: |
+      # Install and set Java 21
+      curl -s "https://get.sdkman.io" | bash
+      source "$HOME/.sdkman/bin/sdkman-init.sh"
+      sdk install java 21.0.1-tem # Installs Java 21 (replace the version if needed)
+      sdk use java 21.0.1-tem     # Sets Java 21 as the active version
+      java -version               # Prints the Java version to confirm
+      mvn install -P quick-build
     command: |
       curl https://gist.githubusercontent.com/timja/fe73f0a0f98afe4d9356e7ce6752d95b/raw/98ad71080e91ed75824ec410ff905419e3788065/init.sh | bash
-      # without host being `0.0.0.0` redirects will go to localhost ignoring the forwarded values for some reason
       mvn hpi:run -Dhost=0.0.0.0
     name: Run
   - command: gp ports await 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,7 @@ tasks:
       mvn install -P quick-build
     command: |
       curl https://gist.githubusercontent.com/timja/fe73f0a0f98afe4d9356e7ce6752d95b/raw/98ad71080e91ed75824ec410ff905419e3788065/init.sh | bash
+      # without host being `0.0.0.0` redirects will go to localhost ignoring the forwarded values for some reason
       mvn hpi:run -Dhost=0.0.0.0
     name: Run
   - command: gp ports await 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,6 @@
 tasks:
   - init: |
+      curl -s "https://get.sdkman.io" | bash
       echo "sdkman_auto_answer=true" > $HOME/.sdkman/etc/config
       sdk install java 21.0.4-tem
       sdk use java 21.0.4-tem

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,8 @@
+image:
+  file: .gitpod/Dockerfile
+
 tasks:
-  - init: |
-      curl -s "https://get.sdkman.io" | bash
-      echo "sdkman_auto_answer=true" > $HOME/.sdkman/etc/config
-      sdk install java 21.0.4-tem
-      sdk use java 21.0.4-tem
-      mvn install -P quick-build
+  - init: mvn install -P quick-build
     command: |
       curl https://gist.githubusercontent.com/timja/fe73f0a0f98afe4d9356e7ce6752d95b/raw/98ad71080e91ed75824ec410ff905419e3788065/init.sh | bash
       # without host being `0.0.0.0` redirects will go to localhost ignoring the forwarded values for some reason

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,11 +1,8 @@
 tasks:
   - init: |
-      # Install and set Java 21
-      curl -s "https://get.sdkman.io" | bash
-      source "$HOME/.sdkman/bin/sdkman-init.sh"
-      sdk install java 21.0.1-tem # Installs Java 21 (replace the version if needed)
-      sdk use java 21.0.1-tem     # Sets Java 21 as the active version
-      java -version               # Prints the Java version to confirm
+      echo "sdkman_auto_answer=true" > $HOME/.sdkman/etc/config
+      sdk install java 21.0.4-tem
+      sdk use java 21.0.4-tem
       mvn install -P quick-build
     command: |
       curl https://gist.githubusercontent.com/timja/fe73f0a0f98afe4d9356e7ce6752d95b/raw/98ad71080e91ed75824ec410ff905419e3788065/init.sh | bash

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,0 +1,16 @@
+FROM gitpod/workspace-full:latest
+
+USER gitpod
+
+# Install Java 21.0.4-tem
+RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && \
+    sdk install java 21.0.4-tem && \
+    sdk default java 21.0.4-tem"
+
+# Install Node.js v20.18.1
+RUN bash -c 'VERSION="20.18.1" && \
+    source $HOME/.nvm/nvm.sh && nvm install $VERSION && \
+    nvm use $VERSION && nvm alias default $VERSION'
+
+# Ensure nvm uses the default version on every new terminal session
+RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,7 +1,3 @@
-FROM gitpod/workspace-full:latest
-
-USER gitpod
-
 # Define version arguments
 ARG JAVA_VERSION=21.0.4-tem
 ARG NODE_VERSION=22.12.0

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -2,15 +2,18 @@ FROM gitpod/workspace-full:latest
 
 USER gitpod
 
-# Install Java 21.0.4-tem
-RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && \
-    sdk install java 21.0.4-tem && \
-    sdk default java 21.0.4-tem"
+# Define version arguments
+ARG JAVA_VERSION=21.0.4-tem
+ARG NODE_VERSION=22.12.0
 
-# Install Node.js v20.18.1
-RUN bash -c 'VERSION="20.18.1" && \
-    source $HOME/.nvm/nvm.sh && nvm install $VERSION && \
-    nvm use $VERSION && nvm alias default $VERSION'
+# Install Java
+RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && \
+    sdk install java ${JAVA_VERSION} && \
+    sdk default java ${JAVA_VERSION}"
+
+# Install Node.js
+RUN bash -c "source $HOME/.nvm/nvm.sh && nvm install ${NODE_VERSION} && \
+    nvm use ${NODE_VERSION} && nvm alias default ${NODE_VERSION}"
 
 # Ensure nvm uses the default version on every new terminal session
 RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,3 +1,6 @@
+# Use the latest Gitpod workspace image
+FROM gitpod/workspace-full:latest
+
 # Define version arguments
 ARG JAVA_VERSION=21.0.4-tem
 ARG NODE_VERSION=22.12.0


### PR DESCRIPTION
Fixes #367

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Changed gitpod.yml file so that it installs java 21 by default . Earlier it was using java 11 by default due to which there were errors in build. Now it installs java 21 at the very start.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
