### PR TITLE
Updated gitpod to use Java 21

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,6 +8,7 @@ tasks:
       mvn install -P quick-build
     command: |
       curl https://gist.githubusercontent.com/timja/fe73f0a0f98afe4d9356e7ce6752d95b/raw/98ad71080e91ed75824ec410ff905419e3788065/init.sh | bash
+      # without host being `0.0.0.0` redirects will go to localhost ignoring the forwarded values for some reason
       mvn hpi:run -Dhost=0.0.0.0
     name: Run
   - command: gp ports await 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,13 @@
 tasks:
-  - init: mvn install -P quick-build
+  - init: |
+      sudo apt-get update
+      sudo apt-get install -y openjdk-21-jdk
+      sudo ln -sf /usr/lib/jvm/java-21-openjdk-amd64/bin/java $(which java)
+      echo 'export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64' >> ~/.bashrc
+      source ~/.bashrc
+      mvn install -P quick-build
     command: |
       curl https://gist.githubusercontent.com/timja/fe73f0a0f98afe4d9356e7ce6752d95b/raw/98ad71080e91ed75824ec410ff905419e3788065/init.sh | bash
-      # without host being `0.0.0.0` redirects will go to localhost ignoring the forwarded values for some reason
       mvn hpi:run -Dhost=0.0.0.0
     name: Run
   - command: gp ports await 8080 && gp url 8080 && gp preview $(gp url 8080)/jenkins/


### PR DESCRIPTION
Fixes [#367](https://github.com/jenkinsci/design-library-plugin/issues/367). This pr automates the process of installing and using Java 21 for Gitpod.

### Testing done
I have tested the changes with Gitpod.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
