### PR TITLE
Add a link to weekly.ci.jenkins.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ which will open the workspace in IntelliJ IDEA using JetBrains Gateway.
 Alternatively clone this project and run `mvn hpi:run`.
 
 Go to the **Design Library** menu item or straight to http://localhost:8080/jenkins/design-library/ and play with UI components.
+
+If you just want to see this plugin in action, then you can also visit the latest version of this plugin in our [Jenkins "weekly" live installation](https://weekly.ci.jenkins.io/design-library/).


### PR DESCRIPTION
See https://weekly.ci.jenkins.io/design-library.

The link has been removed by accident.