### PR TITLE
Fix 'Bottom app bar' sample to not have two 'jenkins-buttons-row' containers

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/AppBar/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/AppBar/index.jelly
@@ -43,12 +43,10 @@
               <div />
             </div>
             <f:bottomButtonBar>
-              <div class="jenkins-buttons-row">
-                <button class="jenkins-button jenkins-button--primary">
-                  Save
-                </button>
-                <button class="jenkins-button">Apply</button>
-              </div>
+              <button class="jenkins-button jenkins-button--primary">
+                Save
+              </button>
+              <button class="jenkins-button">Apply</button>
             </f:bottomButtonBar>
           </div>
         </s:preview>

--- a/src/main/webapp/AppBar/bottomAppBar.jelly
+++ b/src/main/webapp/AppBar/bottomAppBar.jelly
@@ -1,10 +1,8 @@
 <div>
   <f:bottomButtonBar>
-    <div class="jenkins-buttons-row">
-      <button class="jenkins-button jenkins-button--primary">
-        Save
-      </button>
-      <button class="jenkins-button">Apply</button>
-    </div>
+    <button class="jenkins-button jenkins-button--primary">
+      Save
+    </button>
+    <button class="jenkins-button">Apply</button>
   </f:bottomButtonBar>
 </div>


### PR DESCRIPTION
`<f:bottomButtonBar>` already includes a `jenkins-buttons-row` container, so we don't need to duplicate it in our example.
