### PR TITLE
Refine content for error alert

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/Dialogs/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Dialogs/index.jelly
@@ -5,8 +5,8 @@
       <s:group>
         <s:preview>
           <dialog class="jenkins-dialog">
-            <div class="jenkins-dialog__title">Error</div>
-            <div class="jenkins-dialog__contents">This doesn't work.</div>
+            <div class="jenkins-dialog__title">Example alert</div>
+            <div class="jenkins-dialog__contents">I'm an example of an error alert.</div>
             <div class="jenkins-buttons-row jenkins-buttons-row--equal-width jenkins-dialog__buttons">
               <button data-id="ok" type="button"
                       class="jenkins-button jenkins-button--primary jenkins-!-destructive-color">OK

--- a/src/main/webapp/Dialogs/alert.js
+++ b/src/main/webapp/Dialogs/alert.js
@@ -1,5 +1,5 @@
 function showAlert() {
-    dialog.alert("Error", {
-      message: "This doesn't work.", type: "destructive"
+    dialog.alert("Example alert", {
+      message: "I'm an example of an error alert.", type: "destructive"
     });
 }


### PR DESCRIPTION
Updates the content of the error alert so that it's clearer that it's not actually a faulty example, previously it could be read as there being something wrong with the example.

**Before**
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/81e342cf-31ab-4dfa-928f-9f5cde7f59d9" />

**After**
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/5f2b4909-5175-4c80-8e89-129be2f26ad9" />
