### PR TITLE
Fix appearance of sections in samples

### DIFF
--- a/src/main/resources/scss/components/_component-sample.scss
+++ b/src/main/resources/scss/components/_component-sample.scss
@@ -30,6 +30,11 @@
 
   /* Component preview styling */
 
+  & > .jenkins-section {
+    border-top: none;
+    padding-top: 0;
+  }
+
   .jenkins-card {
     margin-bottom: 0;
   }


### PR DESCRIPTION
The latest weekly makes a small change to sections, where the first section now has a border at the top. This messes with out samples a little bit, causing the padding to go a bit off.

**Before**
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/98751bd7-65b9-4556-8578-fbaf89546e02" />

**After**
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/a70d518e-7479-4459-809f-c62cb5e0eb16" />
