### PR TITLE
Fix symbol loading

### DIFF
--- a/src/main/java/io/jenkins/plugins/designlibrary/AppBar.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/AppBar.java
@@ -13,7 +13,7 @@ public class AppBar extends UISample {
 
     @Override
     public String getIconFileName() {
-        return "symbol-app-bar";
+        return "symbol-app-bar plugin-design-library";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Buttons.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Buttons.java
@@ -9,7 +9,7 @@ import hudson.Extension;
 public class Buttons extends UISample {
     @Override
     public String getIconFileName() {
-        return "symbol-buttons";
+        return "symbol-buttons plugin-design-library";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Cards.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Cards.java
@@ -7,7 +7,7 @@ public class Cards extends UISample {
 
     @Override
     public String getIconFileName() {
-        return "symbol-cards";
+        return "symbol-cards plugin-design-library";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Colors.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Colors.java
@@ -8,7 +8,7 @@ import java.util.List;
 public class Colors extends UISample {
     @Override
     public String getIconFileName() {
-        return "symbol-water-outline plugins-ionicons-api";
+        return "symbol-water-outline plugin-ionicons-api";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Inputs.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Inputs.java
@@ -46,7 +46,7 @@ public class Inputs extends UISample {
 
     @Override
     public String getIconFileName() {
-        return "symbol-textbox";
+        return "symbol-textbox plugin-design-library";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Layouts.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Layouts.java
@@ -8,7 +8,7 @@ public class Layouts extends UISample {
 
     @Override
     public String getIconFileName() {
-        return "symbol-layouts";
+        return "symbol-layouts plugin-design-library";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Notifications.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Notifications.java
@@ -9,7 +9,7 @@ import hudson.Extension;
 public class Notifications extends UISample {
     @Override
     public String getIconFileName() {
-        return "symbol-notifications-outline plugins-ionicons-api";
+        return "symbol-notifications-outline plugin-ionicons-api";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Select.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Select.java
@@ -21,7 +21,7 @@ import org.kohsuke.stapler.QueryParameter;
 public class Select extends UISample {
     @Override
     public String getIconFileName() {
-        return "symbol-select";
+        return "symbol-select plugin-design-library";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Spacing.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Spacing.java
@@ -6,7 +6,7 @@ import hudson.Extension;
 public class Spacing extends UISample {
     @Override
     public String getIconFileName() {
-        return "symbol-spacing symbol-design-library";
+        return "symbol-spacing plugin-design-library";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Table.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Table.java
@@ -9,7 +9,7 @@ import hudson.Extension;
 public class Table extends UISample {
     @Override
     public String getIconFileName() {
-        return "symbol-table";
+        return "symbol-table plugin-design-library";
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/designlibrary/Tooltips.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Tooltips.java
@@ -30,7 +30,7 @@ import hudson.Extension;
 public class Tooltips extends UISample {
     @Override
     public String getIconFileName() {
-        return "symbol-tooltips";
+        return "symbol-tooltips plugin-design-library";
     }
 
     @Override

--- a/src/main/resources/lib/samples/sidepanel.jelly
+++ b/src/main/resources/lib/samples/sidepanel.jelly
@@ -12,7 +12,7 @@
     <j:forEach var="s" items="${it.grouped.entrySet()}">
       <div class="app-sidepanel__heading">${s.key.displayName}</div>
       <j:forEach var="s" items="${s.value}">
-        <l:task title="${s.displayName}" href="${rootURL}/design-library/${s.urlName}" icon="${s.iconFileName} plugin-design-library" />
+        <l:task title="${s.displayName}" href="${rootURL}/design-library/${s.urlName}" icon="${s.iconFileName}" />
       </j:forEach>
     </j:forEach>
   </l:tasks>


### PR DESCRIPTION
Due to some ✨ magic ✨ that I don't quite understand, symbols were working when they probably shouldn't have been. The broken symbols were spotted when testing integrating this plugin with the new search overlay. Some symbols lacked the appropriate `plugin-design-library` suffix, and some had their suffix misspelt, e.g. `plugins-ionicons-api` vs `plugin-ionicons-api`.

### Testing done

* Symbols still show as expected

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
