### PR TITLE
Document how to make a textbox mandatory and add a placeholder

### DIFF
--- a/src/main/resources/io/jenkins/plugins/designlibrary/Inputs/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Inputs/index.jelly
@@ -28,11 +28,12 @@
       <s:group>
         <s:preview>
           <f:entry title="Example" field="example">
-            <f:textbox />
+            <f:textbox placeholder="Enter an example"/>
           </f:entry>
         </s:preview>
         <s:code file="example.jelly" />
       </s:group>
+      <p class="jdl-paragraph">${%textbox.usage}</p>
     </s:section>
 
     <s:section title="${%Search}">

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Inputs/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Inputs/index.properties
@@ -12,4 +12,4 @@ syntaxHighlight.description.2=There is support for languages like <code>groovy</
   format (except the start and end bracket) to be passed as CodeMirror option object.
 html.description=To edit html and have a preview you need the <a href="https://plugins.jenkins.io/antisamy-markup-formatter/" target="_blank">OWASP Markup Formatter</a> \
   plugin. Below snippet ensures that when the plugin is not installed that the preview will just print plain text.
-
+textbox.usage=By adding <code>clazz="required"</code> you can mark a textbox as being mandatory.

--- a/src/main/webapp/Inputs/example.jelly
+++ b/src/main/webapp/Inputs/example.jelly
@@ -1,3 +1,3 @@
 <f:entry title="Example" field="example">
-  <f:textbox />
+  <f:textbox placeholder="Enter an example"/>
 </f:entry>


### PR DESCRIPTION
I noticed that developers frequently implement doCheck methods for textboxes with the only purpose to check that it is not empty. We get this for free by adding `clazz="required"`. And the doCheck methods also need to be properly annotated to disable security warnings.

<!-- Please describe your pull request here. -->
![image](https://github.com/user-attachments/assets/3a905d1a-e2b7-49cc-b3a7-a21c46dcacb6)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
