### PR TITLE
Refine 'Colors' page

### DIFF
--- a/src/main/java/io/jenkins/plugins/designlibrary/Colors.java
+++ b/src/main/java/io/jenkins/plugins/designlibrary/Colors.java
@@ -13,7 +13,7 @@ public class Colors extends UISample {
 
     @Override
     public String getDescription() {
-        return "Defines the palette for consistent use of color throughout the design system.";
+        return "Defines the palette for consistent use of color.";
     }
 
     @Override
@@ -23,24 +23,25 @@ public class Colors extends UISample {
 
     public List<Semantic> getSemantics() {
         return List.of(
-                new Semantic("Accent", "Use for branding", "accent-color"),
-                new Semantic("Text", "Use for text", "text-color"),
-                new Semantic("Secondary text", "Use for secondary text", "text-color-secondary"),
-                new Semantic("Success", "Use for success states", "success-color"),
-                new Semantic("Warning", "Use for warning states", "warning-color"),
-                new Semantic("Error", "Use for error states", "error-color"),
-                new Semantic("Build", "Use for build kickoff", "build-color", "play"),
-                new Semantic("Destructive", "Use for destructive actions", "destructive-color", "trash"));
+                new Semantic("Accent", "Use for primary actions.", "accent-color"),
+                new Semantic("Text", "Use for text.", "text-color"),
+                new Semantic("Secondary text", "Use for secondary text.", "text-color-secondary"),
+                new Semantic("Success", "Use for success states.", "success-color"),
+                new Semantic("Warning", "Use for warning states.", "warning-color"),
+                new Semantic("Error", "Use for error states.", "error-color"),
+                new Semantic("Build", "Use for build kickoff.", "build-color", "play"),
+                new Semantic("Destructive", "Use for destructive actions.", "destructive-color", "trash"));
     }
 
     public List<Color> getColors() {
         List<Color> colors = List.of(
                 new Color("Red", "red"),
-                new Color("Green", "green"),
                 new Color("Orange", "orange"),
                 new Color("Yellow", "yellow"),
+                new Color("Green", "green"),
                 new Color("Blue", "blue"),
                 new Color("Cyan", "cyan"),
+                new Color("Teal", "teal"),
                 new Color("Indigo", "indigo"),
                 new Color("Purple", "purple"),
                 new Color("Pink", "pink"),

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.jelly
@@ -40,9 +40,11 @@ THE SOFTWARE.
             </j:if>
             <div class="jdl-colors__item__contents__line">
               <l:copyButton label="Class"
-                            text="jenkins-!-${item.variable}" />
+                            text="jenkins-!-${item.variable}"
+                            iconOnly="true" />
               <l:copyButton label="CSS variable"
-                            text="var(--${item.className ?: item.variable})" />
+                            text="var(--${item.className ?: item.variable})"
+                            iconOnly="true" />
             </div>
           </div>
         </div>

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <d:tag name="item">
       <li>
         <div class="jdl-colors__item" style="--color: var(--${item.className ?: item.variable}, grey);">
-          <p class="jdl-colors__item__title" >
+          <p class="jdl-colors__item__title ${item.className.contains('light') ? 'jdl-colors__item__title--light' : ''} ${item.className.contains('dark') ? 'jdl-colors__item__title--dark' : ''}">
             <j:if test="${item.symbol != null}">
               <l:icon src="symbol-${item.symbol}" />
             </j:if>
@@ -39,12 +39,10 @@ THE SOFTWARE.
               <p class="jdl-colors__item__contents__description">${item.description}</p>
             </j:if>
             <div class="jdl-colors__item__contents__line">
-              <span>var(--${item.className ?: item.variable})</span>
-              <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="var(--${item.className ?: item.variable})" iconOnly="true" />
-            </div>
-            <div class="jdl-colors__item__contents__line">
-              <span>.jenkins-!-${item.variable}</span>
-              <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="jenkins-!-${item.variable}" iconOnly="true" />
+              <l:copyButton label="Class"
+                            text="jenkins-!-${item.variable}" />
+              <l:copyButton label="CSS variable"
+                            text="var(--${item.className ?: item.variable})" />
             </div>
           </div>
         </div>
@@ -62,13 +60,10 @@ THE SOFTWARE.
         <tr>
           <td>${%tip-third}</td>
         </tr>
-        <tr>
-          <td>${%tip-fourth}</td>
-        </tr>
       </s:dos-donts>
     </s:section>
 
-    <s:section title="${%Semantics}">
+    <s:section title="${%Semantic}">
       <ol class="jdl-colors">
         <j:forEach var="item" items="${it.semantics}">
           <local:item item="${item}" />

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.properties
@@ -1,4 +1,4 @@
 tip-first=Use <span class="jdl-colors-tag">color</span> to draw attention to important parts of your interface.
 tip-second=Color shouldn''t be the only way a piece of information is conveyed, use text or symbols along with it.
-tip-third=It''s best to use colors provided by Jenkins as they will automatically adapt to the user''s theme.
+tip-third=Use colors provided by Jenkins as they will automatically adapt to the user''s theme.
 tip-fourth=Primarily use semantic colors in your interface, you can create your own semantic colors using the palette below.

--- a/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.properties
+++ b/src/main/resources/io/jenkins/plugins/designlibrary/Colors/index.properties
@@ -2,5 +2,3 @@ tip-first=Use <span class="jdl-colors-tag">color</span> to draw attention to imp
 tip-second=Color shouldn''t be the only way a piece of information is conveyed, use text or symbols along with it.
 tip-third=It''s best to use colors provided by Jenkins as they will automatically adapt to the user''s theme.
 tip-fourth=Primarily use semantic colors in your interface, you can create your own semantic colors using the palette below.
-clickToCopy=Click to copy
-successfullyCopied=Copied

--- a/src/main/resources/scss/components/_dos-donts.scss
+++ b/src/main/resources/scss/components/_dos-donts.scss
@@ -52,6 +52,7 @@
         top: -4px;
         left: 0;
         border-radius: 100%;
+        border: var(--jenkins-border--subtle);
       }
 
       &::after {

--- a/src/main/resources/scss/components/_dos-donts.scss
+++ b/src/main/resources/scss/components/_dos-donts.scss
@@ -32,6 +32,8 @@
       font-weight: 500;
       font-size: 1.125rem;
       text-align: left;
+      text-box: cap alphabetic;
+      margin-bottom: 0.3125rem;
     }
   }
 

--- a/src/main/resources/scss/components/_section.scss
+++ b/src/main/resources/scss/components/_section.scss
@@ -13,6 +13,7 @@
     font-size: 1.125rem;
     line-height: 1;
     margin: 0;
+    text-box: cap alphabetic;
   }
 
   &__description {
@@ -20,6 +21,7 @@
     max-width: 95ch;
     color: var(--text-color-secondary);
     margin: 0;
+    text-box: cap alphabetic;
   }
 
   &--no-border {

--- a/src/main/resources/scss/pages/_colors.scss
+++ b/src/main/resources/scss/pages/_colors.scss
@@ -102,9 +102,9 @@
             --button-background--hover: transparent !important;
             --button-background--active: transparent !important;
             --button-box-shadow--focus: transparent !important;
+            --text-color: var(--text-color-secondary);
 
             min-height: 0;
-            color: var(--text-color-secondary) !important;
             padding: 0.5rem;
             margin: -0.5rem;
 

--- a/src/main/resources/scss/pages/_colors.scss
+++ b/src/main/resources/scss/pages/_colors.scss
@@ -107,6 +107,7 @@
             min-height: 0;
             padding: 0.5rem;
             margin: -0.5rem;
+            transition: color var(--standard-transition);
 
             &::before {
               border: none;
@@ -114,6 +115,11 @@
 
             .jenkins-copy-button__icon {
               scale: 0.9;
+              transition: color 0s;
+            }
+
+            &:hover {
+              --text-color: unset;
             }
           }
         }

--- a/src/main/resources/scss/pages/_colors.scss
+++ b/src/main/resources/scss/pages/_colors.scss
@@ -56,15 +56,16 @@
         gap: 0.5rem;
         font-weight: var(--font-bold-weight);
         margin: 0;
-        padding: 0.3125rem 1rem;
+        padding: 0 1rem;
+        min-height: 2.25rem;
         background: var(--color);
         border-radius: 100px;
         border: var(--jenkins-border--subtle);
         color: var(--background);
 
         svg {
-          width: 1rem;
-          height: 1rem;
+          width: 1.125rem;
+          height: 1.125rem;
         }
 
         &--light {

--- a/src/main/resources/scss/pages/_colors.scss
+++ b/src/main/resources/scss/pages/_colors.scss
@@ -47,37 +47,32 @@
       display: flex;
       flex-direction: column;
       align-items: start;
-      gap: calc(var(--jdl-spacing) * 0.4);
-
-      .copy-button {
-        opacity: 0;
-        transition: var(--standard-transition);
-      }
-
-      &:hover {
-        .copy-button {
-          opacity: 1;
-        }
-      }
+      gap: calc(var(--jdl-spacing) * 0.5);
 
       .jdl-colors__item__title {
         @include mixins.base-text;
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        font-weight: 450;
+        font-weight: var(--font-bold-weight);
         margin: 0;
-        font-size: 0.875rem;
-        padding: 0.35rem 0.9rem;
+        padding: 0.3125rem 1rem;
         background: var(--color);
-        text-shadow: 0 2px 2px
-          color-mix(in srgb, var(--text-color) 10%, transparent);
         border-radius: 100px;
+        border: var(--jenkins-border--subtle);
         color: var(--background);
 
         svg {
           width: 1rem;
           height: 1rem;
+        }
+
+        &--light {
+          color: oklch(from var(--color) 0.2 c h);
+        }
+
+        &--dark {
+          color: oklch(from var(--color) 1.5 c h);
         }
       }
 
@@ -86,23 +81,10 @@
         display: flex;
         flex-direction: column;
         gap: inherit;
-        padding-left: calc(2rem + 2px);
-
-        &::before {
-          content: "";
-          position: absolute;
-          top: 0.2rem;
-          left: 1rem;
-          bottom: 0.2rem;
-          background: var(--color);
-          border-radius: 100px;
-          width: var(--jenkins-border-width);
-          opacity: 0.2;
-        }
+        padding-left: 1rem;
 
         .jdl-colors__item__contents__description {
           @include mixins.base-text;
-          color: var(--text-color-secondary);
           margin: 0;
         }
 
@@ -112,11 +94,25 @@
           justify-content: start;
           font-family: var(--font-family-mono);
           color: var(--text-color-secondary);
-          opacity: 0.85;
+          gap: 1.5rem;
 
           .jenkins-button {
-            margin-block: -0.66rem;
-            margin-inline-start: 0.33rem;
+            --button-background: transparent !important;
+            --button-background--hover: transparent !important;
+            --button-background--active: transparent !important;
+            --button-box-shadow--focus: transparent !important;
+
+            padding: 0;
+            min-height: 0;
+            color: var(--text-color-secondary) !important;
+
+            &::before {
+              border: none;
+            }
+
+            .jenkins-copy-button__icon {
+              scale: 0.9;
+            }
           }
         }
       }

--- a/src/main/resources/scss/pages/_colors.scss
+++ b/src/main/resources/scss/pages/_colors.scss
@@ -98,27 +98,22 @@
           gap: 1.5rem;
 
           .jenkins-button {
-            --button-background: transparent !important;
-            --button-background--hover: transparent !important;
-            --button-background--active: transparent !important;
-            --button-box-shadow--focus: transparent !important;
             --text-color: var(--text-color-secondary);
 
             min-height: 0;
-            padding: 0.5rem;
-            margin: -0.5rem;
+            padding: 0.5rem 0.625rem;
+            margin: -0.5rem -0.625rem;
             transition: color var(--standard-transition);
-
-            &::before {
-              border: none;
-            }
 
             .jenkins-copy-button__icon {
               scale: 0.9;
-              transition: color 0s;
+              transition:
+                all var(--standard-transition),
+                color 0s;
             }
 
-            &:hover {
+            &:hover,
+            &:focus {
               --text-color: unset;
             }
           }

--- a/src/main/resources/scss/pages/_colors.scss
+++ b/src/main/resources/scss/pages/_colors.scss
@@ -103,9 +103,10 @@
             --button-background--active: transparent !important;
             --button-box-shadow--focus: transparent !important;
 
-            padding: 0;
             min-height: 0;
             color: var(--text-color-secondary) !important;
+            padding: 0.5rem;
+            margin: -0.5rem;
 
             &::before {
               border: none;

--- a/src/main/resources/scss/pages/_home.scss
+++ b/src/main/resources/scss/pages/_home.scss
@@ -17,7 +17,6 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   color: var(--text-color) !important;
   text-decoration: none !important;
   gap: 0.15rem;
@@ -26,7 +25,7 @@
     gap: var(--jdl-spacing);
 
     .jdl-section__title {
-      margin-bottom: calc(var(--jdl-spacing) * -0.75);
+      margin-bottom: calc(var(--jdl-spacing) * -0.25);
     }
 
     .jdl-section__description {


### PR DESCRIPTION
Somewhat relates to https://github.com/jenkinsci/jenkins/pull/10708

I've never been terribly happy with the 'Colors' page as:

- Contrast with some colors was off
- Having to hover to copy was annoying/not accessible
- Poor use of space
- Just _felt_ clumsy

See the old UI at https://weekly.ci.jenkins.io/design-library/colors/

---

This is yet another attempt at the page, and this time I'm feeling relatively happy with it.

![colors](https://github.com/user-attachments/assets/48f40298-e855-41c4-a11a-3e74df91efba)

* Contrast has been improved for light/dark colors - works across themes
* Content has been refined
* Copy buttons are now larger, content changed to 'Class' and 'CSS variable'
* Color order tweaked (ROYGBIV!)
* General QOL improvements
  * Uses the new border from https://github.com/jenkinsci/jenkins/pull/10709 for better contrast
  * Uses newer CSS variables for consistent font sizes and weights

### Testing done

* Works the same as before

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
